### PR TITLE
[codex] Update Homeboard docs for current behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ css/admin.css       — admin mode styles only
 js/shared.js        — Supabase init, VERSION constant, utilities, shared config
 js/display.js       — display mode logic
 js/admin.js         — all admin mode logic (screens, modals, event handling)
+manifest.json       — PWA manifest for display mode (landscape)
+manifest-admin.json — PWA manifest for admin mode (portrait)
 sw.js               — service worker (cache key: homeboard-v##)
 netlify.toml        — build + env var injection via sed
 ```
@@ -32,7 +34,7 @@ netlify.toml        — build + env var injection via sed
 | `todos` | Soft delete only — set `archived_at`, never hard delete |
 | `meal_plan` | `user_id` null = shared (show on display). `user_id` set = personal (admin only) |
 | `meal_plan_notes` | One note per household per week. Keyed by `household_id` + `week_start` (Monday's date) |
-| `countdowns` | `icon` = Lucide icon name string |
+| `countdowns` | `icon` = Lucide icon name string; optional `unsplash_image_url`, `days_before_visible`, and `photo_keyword` drive countdown photos and delayed visibility |
 | `rsvps` | Wedding table — **do not modify schema** |
 | `invited_parties` | Wedding invite list. `rsvp_id` null = pending; set = matched to an RSVP row |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ netlify.toml        — build config, env var injection via sed
 - `todos` — soft delete via `archived_at`, never hard delete
 - `meal_plan` — `user_id` nullable: null = shared/household, uuid = personal
 - `meal_plan_notes` — one note per household per week, keyed by `household_id` + `week_start`
-- `countdowns` — `icon` is a Lucide icon name string e.g. `"plane"`
+- `countdowns` — `icon` is a Lucide icon name string e.g. `"plane"`; optional `unsplash_image_url`, `days_before_visible`, and `photo_keyword` support countdown photos and delayed visibility
 - `rsvps` — pre-existing wedding table, do not modify schema
 - `invited_parties` — wedding invite list with `name`, `invited_count`, nullable `rsvp_id`, and `created_at`; this is the source of truth for matched vs pending invite parties
 
@@ -88,6 +88,7 @@ netlify.toml        — build config, env var injection via sed
 - `display_settings.upcoming_days` drives the `UPCOMING_DAYS` variable in `display.js`. Update both together if changing upcoming-view logic.
 - Google Calendar currently reads a single calendar ID (`households.google_cal_id`). **Future enhancement**: support toggling multiple calendars from the Integrations settings.
 - **Recurring to-dos** are planned for a future PR and will require a schema change to `todos`.
+- Countdown admin supports optional Unsplash photos plus `days_before_visible` timing. Past calendar events are filtered out of the countdown source-event picker, but saved countdown rows are not mutated.
 
 ## Color Palette
 - Background: `#F5F0E8` (warm parchment)

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Both modes are served from `index.html`. Netlify rewrites `/admin` to `index.htm
 
 ## Display Screens
 
-Screens rotate automatically every 30 seconds. Swipe left/right to navigate manually. Nav arrows hide on touch devices.
+Screens rotate automatically using per-screen timers from `display_settings.timer_intervals` with a 30-second fallback. Swipe left/right to navigate manually. Nav arrows hide on touch devices.
 
-1. **This Week** — Google Calendar events for the current 7-day window
+1. **This Week** — Google Calendar events for the configured upcoming window (`display_settings.upcoming_days`, currently 5 or 7 days)
 2. **This Month** — full month calendar grid with events
 3. **To-do List** — shared household tasks with open count and next-up summary
 4. **Dinner Plan** — this week's dinner entries (Mon–Sun)
@@ -40,13 +40,15 @@ Screens rotate automatically every 30 seconds. Swipe left/right to navigate manu
 
 ### Meals
 - Week navigation — previous, current, and next week
-- Tap any day row to open an inline edit form
+- Tap any day row to open the shared bottom-sheet modal
 - Enter dinner name and type (cooking at home, ordering in, going out, leftovers)
-- Save writes directly to the week; cancel closes the inline form
+- Save writes directly to the week; cancel closes the modal
 
 ### Events
 - Tap a Google Calendar event to pre-fill the countdown form
 - Or enter name, date, and Lucide icon name manually
+- Optionally add or refresh an Unsplash background photo for a countdown
+- Optional visibility timing controls let countdowns appear only a set number of days before the event
 - Saved countdowns appear on the display's "Looking Forward" screen
 - Browse icons at [lucide.dev/icons](https://lucide.dev/icons)
 
@@ -72,8 +74,7 @@ Screens rotate automatically every 30 seconds. Swipe left/right to navigate manu
 | `todos` | Soft-delete only — never hard delete; archived via `archived_at` |
 | `meal_plan` | `user_id = null` = shared/household row shown on display |
 | `meal_plan_notes` | One note per household per week; keyed by `household_id` + `week_start` (Monday's date) |
-| `countdowns` (updated) | Added `unsplash_image_url` — stores JSON `{url, credit}` for Unsplash background photos |
-| `countdowns` | `icon` is a Lucide icon name string (e.g. `"plane"`) |
+| `countdowns` | `icon` is a Lucide icon name string; also stores optional `unsplash_image_url`, `days_before_visible`, and `photo_keyword` for countdown photos and visibility timing |
 | `rsvps` | Wedding RSVP table — do not modify schema |
 | `invited_parties` | Wedding invite source of truth. `rsvp_id = null` means pending; set means matched to an RSVP |
 


### PR DESCRIPTION
## Summary
- update `README.md` to match the current display rotation, meals modal flow, and countdown capabilities
- sync `CLAUDE.md` with the live countdown schema and countdown admin behavior
- add the missing manifest files and current countdown field notes to `AGENTS.md`

## Why
The repo docs had drifted from the actual Homeboard behavior, especially around meal editing, countdown photos/visibility timing, and the current display configuration model.

## Impact
This is a docs-only change. It does not change product behavior or require a version bump.

## Validation
- reviewed the updated docs against `js/admin.js`, `js/display.js`, `js/shared.js`, and `netlify.toml`
- confirmed the diff only touches documentation files

AI-assisted: Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated display configuration documentation with configurable timer intervals for screen rotation and dynamic event window duration settings.
  * Enhanced countdown documentation with support for Unsplash background photo integration and visibility timing controls.
  * Clarified Meals admin editing experience using modal-based workflows.
  * Expanded Supabase schema documentation for countdowns with new optional media and visibility fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->