### PR TITLE
Add design token reference docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ netlify.toml        — build + env var injection via sed
 - When pushing any change: always increment `VERSION` in `js/shared.js` by at least a patch bump (use a minor bump for features when appropriate), update `CACHE_NAME` in `sw.js` to match, and keep `README.md` accurate — document new tables, env vars, or screens as they are added
 
 ## Styling Conventions
+- Before writing any CSS or adding styled components, read `TOKENS.md` for the canonical token reference. Always use semantic tokens (`--color-accent`, `--color-accent-subtle`) for new interactive components. Never use `--amber` or `--amber-soft` in new code.
 - Shared corner radius tokens live in `:root` in `index.html`: use `--button-radius` for admin/display buttons and `--tag-radius` for pills, badges, and other tag-like labels
 - Keep admin action-button sizing responsive: on screens up to 480 px, a lone primary action should fill the row and two-button action rows should split into equal widths
 - The admin nav is a fixed bottom bar pinned flush to the viewport edge; do not reintroduce floating gaps, translucent glass treatment, or drop shadows there

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ netlify.toml        — build config, env var injection via sed
 - Muted text: `#78716C` (warm gray)
 
 ## Styling Conventions
+- Before writing any CSS or adding styled components, read `TOKENS.md` for the canonical token reference. Always use semantic tokens (`--color-accent`, `--color-accent-subtle`) for new interactive components. Never use `--amber` or `--amber-soft` in new code.
 - Shared corner-radius tokens live in `:root` in `index.html`: use `--button-radius` for interactive buttons and `--tag-radius` for pills, badges, date chips, and other tag-like UI
 - On admin mobile layouts up to `480px`, single primary actions should run full width and two-button action rows should split evenly across the row
 - The admin nav is a fixed bottom bar pinned flush to the bottom edge of the viewport; keep toast positioning above it so nav actions stay accessible

--- a/TOKENS.md
+++ b/TOKENS.md
@@ -1,0 +1,138 @@
+# TOKENS.md
+
+Canonical reference for CSS design tokens in Homeboard. Any agent should read this file before touching CSS or adding a new styled component.
+
+## 1. How color schemes work
+
+Homeboard has three color schemes:
+
+- `Warm` is the default scheme defined in `:root` in [index.html](/Users/chrisaugustine/projects/homeboard/index.html).
+- `Dark` is defined in [css/display.css](/Users/chrisaugustine/projects/homeboard/css/display.css) under `html[data-scheme="dark"]`.
+- `Slate` is defined in [css/display.css](/Users/chrisaugustine/projects/homeboard/css/display.css) under `html[data-scheme="slate"]`.
+
+The active scheme is applied by `applyColorScheme()` in [js/display.js](/Users/chrisaugustine/projects/homeboard/js/display.js). That function sets or removes the `data-scheme` attribute on the `<html>` element:
+
+- no `data-scheme` attribute = Warm
+- `data-scheme="dark"` = Dark
+- `data-scheme="slate"` = Slate
+
+## 2. Semantic tokens — ALWAYS use these for new components
+
+These are the canonical interaction tokens for any new component.
+
+### `--color-accent`
+
+Current values by scheme:
+
+| Scheme | Value | Notes |
+|---|---|---|
+| Warm | `#b45309` | terracotta |
+| Dark | `#f59e0b` | gold |
+| Slate | `#0369a1` | blue |
+
+Use for:
+
+- primary interactive elements
+- active states
+- selected states
+- focus indicators
+- any element that needs to stand out as the primary action or selection
+
+### `--color-accent-subtle`
+
+Current values by scheme:
+
+| Scheme | Value | Notes |
+|---|---|---|
+| Warm | `#f7d9aa` | soft peach |
+| Dark | `rgba(245, 158, 11, 0.18)` | soft gold, low opacity |
+| Slate | `rgba(3, 105, 161, 0.11)` | soft blue, low opacity |
+
+Use for:
+
+- background fills on active or selected elements where a full accent color would be too heavy
+- hover states
+- selected row backgrounds
+- subtle highlights
+
+Note: on light schemes (`Warm`, `Slate`) this is too subtle for nav active states. Use `--color-accent` instead for those.
+
+### `--color-text-on-accent`
+
+Current values by scheme:
+
+| Scheme | Value |
+|---|---|
+| Warm | `#ffffff` |
+| Dark | `#ffffff` |
+| Slate | `#ffffff` |
+
+Use for:
+
+- text rendered on top of `--color-accent`
+- icons rendered on top of `--color-accent`
+
+## 3. Legacy tokens — do not use for new components
+
+Warning: these tokens are legacy and should not be used in any new component.
+
+### `--amber` and `--amber-soft`
+
+These tokens exist in all three scheme blocks, but the names are misleading. In Slate, `--amber` is blue (`#0369a1`), not amber.
+
+They predate the semantic token system and are being migrated out. Do not reference them in new components. Use `--color-accent` and `--color-accent-subtle` instead.
+
+Migration status:
+
+- partially complete
+- `--display-nav-active-bg` has already been migrated
+- all other references are still using legacy tokens and should be updated in the Phase 2 token audit PR
+
+## 4. Component-scoped tokens — use only within their component
+
+The following RSVP tokens are intentionally component-scoped:
+
+- `--rsvp-pending-bg`
+- `--rsvp-review-bg-flagged`
+- `--rsvp-review-bg-clear`
+- `--rsvp-attending-pill-bg`
+- `--rsvp-attending-pill-color`
+- `--rsvp-undercount-pill-bg`
+- `--rsvp-undercount-pill-color`
+- `--rsvp-clear`
+- `--rsvp-flagged`
+
+These are correct and intentional for RSVP admin components. Do not use them outside RSVP components.
+
+If a non-RSVP component needs a similar color treatment, use `--color-accent` or `--color-accent-subtle` instead.
+
+## 5. Structural tokens — reference freely
+
+These tokens are safe to use anywhere in the project:
+
+- `--bg`, `--bg-soft`: page and surface backgrounds
+- `--panel`, `--panel-strong`: card and panel backgrounds
+- `--ink`: primary text color
+- `--muted`: secondary or muted text
+- `--border`: default border color
+- `--shadow`: box shadow
+- `--radius-lg`, `--radius-md`, `--radius-sm`: border radius for cards and containers
+- `--button-radius`: `8px`, use for all interactive buttons
+- `--tag-radius`: `12px`, use for all tags and pills
+- `--sage`, `--sage-soft`: success and positive states
+- `--rose`, `--rose-soft`: error, negative, and love states
+- `--transition`: standard animation timing
+
+## 6. Token naming convention for new tokens
+
+Any new token added to the project should follow this pattern:
+
+- semantic purpose tokens: `--color-[purpose]` such as `--color-accent` or `--color-accent-subtle`
+- component-scoped tokens: `--[component]-[purpose]` such as `--rsvp-pending-bg` or `--scorecard-active-player-bg`
+- never name a token after a color such as `--amber` or `--blue` unless it is a raw palette entry that is not intended for direct use
+
+## 7. Phase 2 audit — what still needs to be done
+
+- Find all references to `var(--amber)` and `var(--amber-soft)` outside of their token definitions and update them to `--color-accent` or `--color-accent-subtle` as appropriate.
+- Confirm all `--rsvp-*` tokens are only used in RSVP components.
+- Remove `--display-nav-button-radius` if it is still present and unused.


### PR DESCRIPTION
## Summary
- add `TOKENS.md` as the canonical design token reference and migration guide for Homeboard
- update `AGENTS.md` and `CLAUDE.md` to require reading `TOKENS.md` before CSS or styled-component work

## Validation
- documentation-only change; no runtime code or CSS behavior changed

AI-assisted: Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CSS design tokens reference documentation, establishing color scheme mappings and semantic token usage guidelines.
  * Updated styling conventions to require token documentation consultation and enforce use of semantic accent tokens for new interactive components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->