### PR TITLE
fix: display sync lag, stale dates, and version update delays

### DIFF
--- a/js/display-init.js
+++ b/js/display-init.js
@@ -232,6 +232,18 @@
       });
       window.addEventListener("keydown", handleKeydown);
 
+      // On visibility restore (screen wake, tab switch back): run a full sync if the
+      // last sync was more than 60 seconds ago. Handles Android timer throttling and
+      // ensures dates, todos, and SW version are fresh when the display wakes up.
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState !== "visible") return;
+        const lastSynced = localStorage.getItem(LAST_SYNCED_KEY);
+        const elapsed = lastSynced ? Date.now() - new Date(lastSynced).getTime() : Infinity;
+        if (elapsed >= 60 * 1000) {
+          runFullSync();
+        }
+      });
+
       // Every 5 min: narrow refresh; automatically escalate to wide if 24h have passed
       window.setInterval(() => {
         const needsWide = (Date.now() - lastWideFetch) >= 24 * 60 * 60 * 1000;

--- a/js/display-init.js
+++ b/js/display-init.js
@@ -258,10 +258,12 @@
         if (!shouldHideRsvpScreen() && track.querySelector(".rsvp-screen")) {
           renderRsvpBoardWithData();
         }
-        Promise.all([fetchTodos(), fetchMeals(), fetchWeeklyNote()]).then(([remoteTodos, remoteMeals, weeklyNote]) => {
-          if (remoteTodos !== null) renderTodoItems(remoteTodos);
-          if (remoteMeals !== null) renderMeals(remoteMeals, weeklyNote || "");
-        }).catch(() => {});
+        Promise.allSettled([fetchTodos(), fetchMeals(), fetchWeeklyNote()]).then(([todosResult, mealsResult, noteResult]) => {
+          if (todosResult.status === "fulfilled" && todosResult.value !== null) renderTodoItems(todosResult.value);
+          if (mealsResult.status === "fulfilled" && mealsResult.value !== null) {
+            renderMeals(mealsResult.value, noteResult.status === "fulfilled" ? (noteResult.value || "") : "");
+          }
+        });
       }, 5 * 60 * 1000);
 
       // Week navigation — each click resets the rotation timer

--- a/js/display-init.js
+++ b/js/display-init.js
@@ -248,7 +248,9 @@
       // for a new service worker so version updates appear without a manual sync.
       window.setInterval(runFullSync, 15 * 60 * 1000);
 
-      // Every 5 min: narrow refresh; automatically escalate to wide if 24h have passed
+      // Every 5 min: narrow refresh; automatically escalate to wide if 24h have passed.
+      // Todos and meals are included so content changes from admin appear within 5 min
+      // even between the 15-minute full syncs.
       window.setInterval(() => {
         const needsWide = (Date.now() - lastWideFetch) >= 24 * 60 * 60 * 1000;
         refreshCalendarData(needsWide);
@@ -256,6 +258,10 @@
         if (!shouldHideRsvpScreen() && track.querySelector(".rsvp-screen")) {
           renderRsvpBoardWithData();
         }
+        Promise.all([fetchTodos(), fetchMeals(), fetchWeeklyNote()]).then(([remoteTodos, remoteMeals, weeklyNote]) => {
+          if (remoteTodos !== null) renderTodoItems(remoteTodos);
+          if (remoteMeals !== null) renderMeals(remoteMeals, weeklyNote || "");
+        }).catch(() => {});
       }, 5 * 60 * 1000);
 
       // Week navigation — each click resets the rotation timer

--- a/js/display-init.js
+++ b/js/display-init.js
@@ -252,6 +252,7 @@
       // Todos and meals are included so content changes from admin appear within 5 min
       // even between the 15-minute full syncs.
       window.setInterval(() => {
+        if (isSyncing) return;
         const needsWide = (Date.now() - lastWideFetch) >= 24 * 60 * 60 * 1000;
         refreshCalendarData(needsWide);
         renderScorecardsWithData();

--- a/js/display-init.js
+++ b/js/display-init.js
@@ -1,3 +1,5 @@
+    let lastWeeklyNote = "";
+
     function initDisplayMode() {
       displayApp.hidden = false;
       adminApp.hidden = true;
@@ -261,9 +263,8 @@
         }
         Promise.allSettled([fetchTodos(), fetchMeals(), fetchWeeklyNote()]).then(([todosResult, mealsResult, noteResult]) => {
           if (todosResult.status === "fulfilled" && todosResult.value !== null) renderTodoItems(todosResult.value);
-          if (mealsResult.status === "fulfilled" && mealsResult.value !== null) {
-            renderMeals(mealsResult.value, noteResult.status === "fulfilled" ? (noteResult.value || "") : "");
-          }
+          if (noteResult.status === "fulfilled" && noteResult.value !== null) lastWeeklyNote = noteResult.value;
+          if (mealsResult.status === "fulfilled" && mealsResult.value !== null) renderMeals(mealsResult.value, lastWeeklyNote);
         });
       }, 5 * 60 * 1000);
 

--- a/js/display-init.js
+++ b/js/display-init.js
@@ -244,6 +244,10 @@
         }
       });
 
+      // Every 15 min: full sync — fetches todos, meals, config, countdowns, and checks
+      // for a new service worker so version updates appear without a manual sync.
+      window.setInterval(runFullSync, 15 * 60 * 1000);
+
       // Every 5 min: narrow refresh; automatically escalate to wide if 24h have passed
       window.setInterval(() => {
         const needsWide = (Date.now() - lastWideFetch) >= 24 * 60 * 60 * 1000;

--- a/js/display-init.js
+++ b/js/display-init.js
@@ -244,9 +244,9 @@
         }
       });
 
-      // Every 15 min: full sync — fetches todos, meals, config, countdowns, and checks
+      // Every 30 min: full sync — fetches todos, meals, config, countdowns, and checks
       // for a new service worker so version updates appear without a manual sync.
-      window.setInterval(runFullSync, 15 * 60 * 1000);
+      window.setInterval(runFullSync, 30 * 60 * 1000);
 
       // Every 5 min: narrow refresh; automatically escalate to wide if 24h have passed.
       // Todos and meals are included so content changes from admin appear within 5 min

--- a/js/shared.js
+++ b/js/shared.js
@@ -28,7 +28,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "1.9.8";
+    const VERSION = "1.9.9";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -28,7 +28,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "1.9.10";
+    const VERSION = "1.9.11";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -28,7 +28,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "1.9.11";
+    const VERSION = "1.9.12";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -28,7 +28,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "1.9.5";
+    const VERSION = "1.9.6";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -28,7 +28,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "1.9.6";
+    const VERSION = "1.9.7";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -28,7 +28,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "1.9.7";
+    const VERSION = "1.9.8";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -28,7 +28,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "1.9.9";
+    const VERSION = "1.9.10";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v1.9.10";
+const CACHE_NAME = "homeboard-v1.9.11";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v1.9.9";
+const CACHE_NAME = "homeboard-v1.9.10";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v1.9.7";
+const CACHE_NAME = "homeboard-v1.9.8";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v1.9.11";
+const CACHE_NAME = "homeboard-v1.9.12";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v1.9.8";
+const CACHE_NAME = "homeboard-v1.9.9";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v1.9.6";
+const CACHE_NAME = "homeboard-v1.9.7";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v1.9.5";
+const CACHE_NAME = "homeboard-v1.9.6";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary

- Added `visibilitychange` listener to run a full sync whenever the tablet screen wakes up, fixing stale dates and content lag caused by Android timer throttling while the screen is off
- Added a 30-minute `setInterval` that calls `runFullSync` automatically so todos, meals, config, countdowns, and the SW update check all run without user action
- Expanded the existing 5-minute background interval to include todos and meals, so admin changes appear within 5 minutes instead of waiting for a manual sync

## Test plan

- [x] Make a change in admin (new todo, meal update) — verify it appears on the display within 5 minutes without tapping sync
- [ ] Turn the tablet screen off for several minutes, turn it back on — verify a sync fires immediately on wake
- [ ] Deploy a new version to Netlify — verify the display picks it up within 30 minutes without a manual reload
- [ ] Let the display run past midnight — verify the date updates correctly without a manual sync

Authored with Claude Code (claude-sonnet-4-6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-syncs when you return to the tab if last sync was >60s.
  * Periodic background syncing: light refresh every 5 minutes now also updates todos, meals, and the weekly note; a full comprehensive sync runs every 30 minutes.

* **Chores**
  * Updated application version and service worker cache to 1.9.12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->