### PR TITLE
Add admin user preferences and reorganize settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Core tables used by Homeboard:
 | Table | Purpose |
 |---|---|
 | `households` | household-level settings such as assistant name, color scheme, Google Calendar ID, and `display_settings` |
-| `users` | maps authenticated Supabase users to a household and role |
+| `users` | maps authenticated Supabase users to a household and role, and stores personal admin settings such as `display_name` and `preferences.admin_theme` |
 | `todos` | household to-dos; never hard-deleted |
 | `meal_plan` | weekly meal entries |
 | `meal_plan_notes` | one note per household per week |

--- a/css/admin.css
+++ b/css/admin.css
@@ -1893,6 +1893,13 @@
       color: var(--muted);
     }
 
+    .admin-settings-divider {
+      height: 1px;
+      width: 100%;
+      background: rgba(124, 96, 69, 0.14);
+      margin: -2px 0 2px;
+    }
+
     .admin-display-pairing-card {
       display: grid;
       gap: 8px;
@@ -2233,20 +2240,22 @@
     .admin-settings-footer-sync {
       display: flex;
       align-items: center;
-      gap: 14px;
-      justify-content: flex-end;
+      justify-content: center;
+      gap: 8px;
       margin: 4px 2px 0;
-      flex-wrap: wrap;
+      flex-wrap: nowrap;
       min-height: 20px;
     }
 
     .admin-settings-footer-sync .last-synced-label {
       font-size: 0.72rem;
       opacity: 0.66;
+      text-align: center;
     }
 
     .admin-settings-footer-sync .sync-btn {
       opacity: 0.62;
+      flex-shrink: 0;
     }
 
     .admin-settings-account-actions {
@@ -2274,13 +2283,7 @@
       }
 
       .admin-settings-footer-sync {
-        display: grid;
-        gap: 10px;
-        justify-items: end;
-      }
-
-      .admin-settings-footer-sync .sync-btn {
-        justify-self: end;
+        gap: 8px;
       }
     }
 

--- a/css/admin.css
+++ b/css/admin.css
@@ -1874,6 +1874,10 @@
       margin-top: 14px;
     }
 
+    .admin-settings-account-status {
+      margin: 0;
+    }
+
     .admin-settings-subsection {
       display: grid;
       gap: 10px;
@@ -2226,39 +2230,27 @@
       font-size: 0.9rem;
     }
 
-    /* Sync row */
-    .admin-sync-row {
+    .admin-settings-footer-sync {
       display: flex;
       align-items: center;
       gap: 14px;
-      margin-top: 10px;
+      justify-content: flex-end;
+      margin: 4px 2px 0;
       flex-wrap: wrap;
+      min-height: 20px;
     }
 
-    .admin-sync-btn {
-      display: flex;
-      align-items: center;
-      gap: 7px;
+    .admin-settings-footer-sync .last-synced-label {
+      font-size: 0.72rem;
+      opacity: 0.66;
     }
 
-    .admin-sync-btn svg {
-      width: 15px;
-      height: 15px;
-      flex-shrink: 0;
+    .admin-settings-footer-sync .sync-btn {
+      opacity: 0.62;
     }
 
-    .admin-sync-btn.is-syncing svg {
-      animation: admin-spin 1s linear infinite;
-    }
-
-    @keyframes admin-spin {
-      to { transform: rotate(360deg); }
-    }
-
-    .admin-sync-timestamp {
-      font-size: 0.78rem;
-      color: var(--muted);
-      font-weight: 600;
+    .admin-settings-account-actions {
+      margin-top: 10px;
     }
 
     /* End-aligned actions row */
@@ -2281,14 +2273,14 @@
         width: 50%;
       }
 
-      .admin-sync-row {
+      .admin-settings-footer-sync {
         display: grid;
         gap: 10px;
+        justify-items: end;
       }
 
-      .admin-sync-row .admin-sync-btn {
-        width: 100%;
-        justify-content: center;
+      .admin-settings-footer-sync .sync-btn {
+        justify-self: end;
       }
     }
 
@@ -2324,8 +2316,7 @@
     html[data-scheme="dark"] .admin-settings-timer-label,
     html[data-scheme="dark"] .admin-settings-toggle span,
     html[data-scheme="dark"] .admin-settings-scheme-option span:last-child,
-    html[data-scheme="dark"] .admin-version-label,
-    html[data-scheme="dark"] .admin-sync-timestamp {
+    html[data-scheme="dark"] .admin-version-label {
       color: var(--ink);
     }
 

--- a/css/admin.css
+++ b/css/admin.css
@@ -2242,7 +2242,7 @@
       align-items: center;
       justify-content: center;
       gap: 8px;
-      margin: 4px 2px 0;
+      margin: 16px 2px 0;
       flex-wrap: nowrap;
       min-height: 20px;
     }

--- a/index.html
+++ b/index.html
@@ -474,32 +474,33 @@
 
       <section class="admin-screen" id="admin-screen-settings" data-admin-screen="settings" hidden>
 
-        <!-- Assistant Name -->
-        <section class="admin-panel" aria-labelledby="settings-assistant-title">
-          <h2 class="admin-panel-title" id="settings-assistant-title">Assistant Name</h2>
+        <!-- Household -->
+        <section class="admin-panel" aria-labelledby="settings-household-title">
+          <h2 class="admin-panel-title" id="settings-household-title">Household</h2>
           <div class="admin-settings-stack">
             <div class="admin-settings-subsection">
-              <p class="admin-field-hint">Shown in the bottom bar of the display view.</p>
-              <input id="settings-assistant-name" class="admin-input" type="text" maxlength="60"
-                placeholder="Leave blank to show &ldquo;Homeboard&rdquo;" autocomplete="off" aria-label="Assistant name">
+              <div class="admin-field">
+                <label for="settings-assistant-name">Assistant name</label>
+                <p class="admin-field-hint">Shown in the bottom bar of the display view.</p>
+                <input id="settings-assistant-name" class="admin-input" type="text" maxlength="60"
+                  placeholder="Leave blank to show &ldquo;Homeboard&rdquo;" autocomplete="off" aria-label="Assistant name">
+              </div>
+              <div class="admin-actions admin-actions--end">
+                <button type="button" id="settings-assistant-save"
+                  class="admin-button admin-button--primary">Save</button>
+              </div>
             </div>
-          </div>
-          <div class="admin-actions admin-actions--end">
-            <button type="button" id="settings-assistant-save"
-              class="admin-button admin-button--primary">Save</button>
-          </div>
-        </section>
 
-        <!-- Household Members -->
-        <section class="admin-panel" aria-labelledby="settings-members-title">
-          <h2 class="admin-panel-title" id="settings-members-title">Household Members</h2>
-          <div class="admin-settings-stack">
-            <div id="settings-members-list" class="admin-settings-member-list"></div>
-            <div class="admin-form-row admin-form-row--add-member">
-              <input id="settings-member-input" class="admin-input" type="text" maxlength="60"
-                placeholder="Member name" autocomplete="off">
-              <button type="button" id="settings-member-add-btn"
-                class="admin-button admin-button--primary">Save</button>
+            <div class="admin-settings-subsection">
+              <div class="admin-settings-subsection-label">Household members</div>
+              <p class="admin-field-hint">Used for to-do assignees across admin and display.</p>
+              <div id="settings-members-list" class="admin-settings-member-list"></div>
+              <div class="admin-form-row admin-form-row--add-member">
+                <input id="settings-member-input" class="admin-input" type="text" maxlength="60"
+                  placeholder="Member name" autocomplete="off">
+                <button type="button" id="settings-member-add-btn"
+                  class="admin-button admin-button--primary">Save</button>
+              </div>
             </div>
           </div>
         </section>
@@ -567,7 +568,7 @@
             </div>
 
             <div class="admin-field">
-              <label>Color scheme</label>
+              <label>Display color scheme</label>
               <div class="admin-settings-scheme-list" id="settings-color-scheme">
                 <label class="admin-settings-scheme-option">
                   <input type="radio" name="color_scheme" value="warm">
@@ -584,6 +585,19 @@
                   <span class="admin-settings-scheme-swatch admin-settings-scheme-swatch--slate"></span>
                   <span>Slate</span>
                 </label>
+              </div>
+            </div>
+
+            <div class="admin-settings-subsection">
+              <div class="admin-settings-subsection-label">Display pairing</div>
+              <p class="admin-field-hint">Generate a one-time code, then enter it on the tablet to connect this display to your household.</p>
+              <div class="admin-display-pairing-card" id="settings-display-pairing-card">
+                <div class="admin-display-pairing-status" id="settings-display-pairing-status">No active pairing code</div>
+                <div class="admin-display-pairing-code" id="settings-display-pairing-code" hidden>----</div>
+                <div class="admin-display-pairing-expiry" id="settings-display-pairing-expiry" hidden></div>
+              </div>
+              <div class="admin-actions admin-actions--end">
+                <button type="button" id="settings-display-pairing-generate" class="admin-button admin-button--primary">Generate pairing code</button>
               </div>
             </div>
 
@@ -613,47 +627,56 @@
           </div>
         </section>
 
-        <!-- Display Setup -->
-        <section class="admin-panel" aria-labelledby="settings-pairing-title">
-          <h2 class="admin-panel-title" id="settings-pairing-title">Display Setup</h2>
+        <!-- Account -->
+        <section class="admin-panel" aria-labelledby="settings-account-title">
+          <h2 class="admin-panel-title" id="settings-account-title">Account</h2>
           <div class="admin-settings-stack">
-            <div class="admin-settings-subsection">
-              <p class="admin-field-hint">Generate a one-time code, then enter it on the tablet to connect this display to your household.</p>
-              <div class="admin-display-pairing-card" id="settings-display-pairing-card">
-                <div class="admin-display-pairing-status" id="settings-display-pairing-status">No active pairing code</div>
-                <div class="admin-display-pairing-code" id="settings-display-pairing-code" hidden>----</div>
-                <div class="admin-display-pairing-expiry" id="settings-display-pairing-expiry" hidden></div>
+            <div id="settings-account-name" class="admin-field-hint admin-settings-account-status"></div>
+
+            <div class="admin-field">
+              <label for="settings-display-name">Display name</label>
+              <input id="settings-display-name" class="admin-input" type="text" maxlength="80"
+                placeholder="Your name" autocomplete="name">
+            </div>
+
+            <div class="admin-field">
+              <label>Admin theme</label>
+              <p class="admin-field-hint">This only changes the look of your admin app.</p>
+              <div class="admin-settings-scheme-list" id="settings-admin-theme">
+                <label class="admin-settings-scheme-option">
+                  <input type="radio" name="admin_theme" value="warm">
+                  <span class="admin-settings-scheme-swatch admin-settings-scheme-swatch--warm"></span>
+                  <span>Warm</span>
+                </label>
+                <label class="admin-settings-scheme-option">
+                  <input type="radio" name="admin_theme" value="dark">
+                  <span class="admin-settings-scheme-swatch admin-settings-scheme-swatch--dark"></span>
+                  <span>Dark</span>
+                </label>
+                <label class="admin-settings-scheme-option">
+                  <input type="radio" name="admin_theme" value="slate">
+                  <span class="admin-settings-scheme-swatch admin-settings-scheme-swatch--slate"></span>
+                  <span>Slate</span>
+                </label>
               </div>
             </div>
           </div>
           <div class="admin-actions admin-actions--end">
-            <button type="button" id="settings-display-pairing-generate" class="admin-button admin-button--primary">Generate pairing code</button>
+            <button type="button" id="settings-account-save"
+              class="admin-button admin-button--primary">Save</button>
           </div>
-        </section>
-
-        <!-- Sync -->
-        <section class="admin-panel" aria-labelledby="settings-sync-title">
-          <h2 class="admin-panel-title" id="settings-sync-title">Sync</h2>
-          <p class="admin-field-hint">Re-fetches all data and checks for app updates. If a new version is available, the page reloads automatically.</p>
-          <div class="admin-sync-row">
-            <button type="button" id="settings-sync-btn"
-              class="admin-button admin-button--primary admin-sync-btn">
-              <i data-lucide="refresh-cw"></i>
-              Sync now
-            </button>
-            <span id="settings-last-synced" class="admin-sync-timestamp"></span>
-          </div>
-        </section>
-
-        <!-- Account -->
-        <section class="admin-panel" aria-labelledby="settings-account-title">
-          <h2 class="admin-panel-title" id="settings-account-title">Account</h2>
-          <div id="settings-account-name" class="admin-field-hint" style="margin-bottom:12px"></div>
-          <div class="admin-actions admin-actions--end">
+          <div class="admin-actions admin-actions--end admin-settings-account-actions">
             <button type="button" id="settings-logout-btn"
               class="admin-button admin-button--secondary">Sign out</button>
           </div>
         </section>
+
+        <div class="admin-settings-footer-sync" aria-live="polite">
+          <span id="settings-last-synced" class="last-synced-label"></span>
+          <button class="sync-btn" id="settings-sync-btn" type="button" aria-label="Sync now">
+            <i data-lucide="refresh-cw"></i>
+          </button>
+        </div>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -588,6 +588,13 @@
               </div>
             </div>
 
+            <div class="admin-actions admin-actions--end">
+              <button type="button" id="settings-display-save"
+                class="admin-button admin-button--primary">Save</button>
+            </div>
+
+            <div class="admin-settings-divider" aria-hidden="true"></div>
+
             <div class="admin-settings-subsection">
               <div class="admin-settings-subsection-label">Display pairing</div>
               <p class="admin-field-hint">Generate a one-time code, then enter it on the tablet to connect this display to your household.</p>
@@ -601,10 +608,6 @@
               </div>
             </div>
 
-          </div>
-          <div class="admin-actions admin-actions--end">
-            <button type="button" id="settings-display-save"
-              class="admin-button admin-button--primary">Save</button>
           </div>
         </section>
 
@@ -637,6 +640,7 @@
               <label for="settings-display-name">Display name</label>
               <input id="settings-display-name" class="admin-input" type="text" maxlength="80"
                 placeholder="Your name" autocomplete="name">
+              <p class="admin-field-hint">Used when assigning to-dos and identifying you in the household.</p>
             </div>
 
             <div class="admin-field">
@@ -672,10 +676,10 @@
         </section>
 
         <div class="admin-settings-footer-sync" aria-live="polite">
-          <span id="settings-last-synced" class="last-synced-label"></span>
           <button class="sync-btn" id="settings-sync-btn" type="button" aria-label="Sync now">
             <i data-lucide="refresh-cw"></i>
           </button>
+          <span id="settings-last-synced" class="last-synced-label"></span>
         </div>
 
       </section>

--- a/js/admin-core.js
+++ b/js/admin-core.js
@@ -4,6 +4,16 @@
     let adminUiStarted = false;
     let adminLastSyncedInterval = null;
 
+    function normalizeAdminTheme(theme) {
+      return ["warm", "dark", "slate"].includes(theme) ? theme : "warm";
+    }
+
+    function applyAdminTheme(theme) {
+      if (typeof applyColorScheme === "function") {
+        applyColorScheme(normalizeAdminTheme(theme));
+      }
+    }
+
     function getAdminHouseholdId() {
       return adminCurrentHouseholdId || DISPLAY_HOUSEHOLD_ID;
     }
@@ -25,7 +35,7 @@
       try {
         const { data, error } = await client
           .from("users")
-          .select("household_id, display_name")
+          .select("household_id, display_name, preferences")
           .eq("id", authUserId)
           .single();
         if (error || !data) return null;
@@ -33,6 +43,23 @@
       } catch {
         return null;
       }
+    }
+
+    function buildAdminCurrentUser(authUserId, userRow) {
+      const preferences = userRow?.preferences && typeof userRow.preferences === "object"
+        ? { ...userRow.preferences }
+        : {};
+      const adminTheme = normalizeAdminTheme(preferences.admin_theme);
+
+      return {
+        id: authUserId,
+        displayName: userRow?.display_name || "",
+        householdId: userRow?.household_id || DISPLAY_HOUSEHOLD_ID,
+        preferences: {
+          ...preferences,
+          admin_theme: adminTheme
+        }
+      };
     }
 
     async function doAdminLogin(email, password) {
@@ -47,10 +74,12 @@
         } catch {}
         adminCurrentHouseholdId = DISPLAY_HOUSEHOLD_ID;
         adminCurrentUser = null;
+        applyAdminTheme("warm");
         throw new Error("Account not found in household");
       }
       adminCurrentHouseholdId = userRow.household_id;
-      adminCurrentUser = { displayName: userRow.display_name, householdId: userRow.household_id };
+      adminCurrentUser = buildAdminCurrentUser(data.user.id, userRow);
+      applyAdminTheme(adminCurrentUser.preferences?.admin_theme);
       return adminCurrentUser;
     }
 
@@ -66,6 +95,7 @@
       adminUiStarted = false;
       adminCurrentHouseholdId = DISPLAY_HOUSEHOLD_ID;
       adminCurrentUser = null;
+      applyAdminTheme("warm");
       const mainContent = document.getElementById("admin-main-content");
       const loginScreen = document.getElementById("admin-login-screen");
       if (mainContent) mainContent.hidden = true;
@@ -208,6 +238,7 @@
     let displaySavePending = false;
     let displayPairingGeneratePending = false;
     let integrationsSavePending = false;
+    let accountSavePending = false;
     let membersSavePending = false;
     let pendingMemberRemovalIndex = null;
     let adminHouseholdConfigPromise = null;
@@ -265,6 +296,8 @@
         "settings-assistant-save",
         "settings-member-input",
         "settings-member-add-btn",
+        "settings-google-cal-id",
+        "settings-display-pairing-generate",
         "settings-display-save",
         "settings-integrations-save"
       ];
@@ -276,11 +309,15 @@
         }
       });
 
-      const displayInputs = document.querySelectorAll("#admin-screen-settings input, #admin-screen-settings select, #admin-screen-settings button");
+      const displayInputs = document.querySelectorAll([
+        "#settings-screen-toggles input",
+        "#settings-screen-order button",
+        "#settings-timer-list input",
+        "#settings-color-scheme input",
+        "#settings-upcoming-days"
+      ].join(", "));
       displayInputs.forEach((element) => {
-        if (element.id !== "settings-sync-btn") {
-          element.disabled = disabled;
-        }
+        element.disabled = disabled;
       });
     }
 
@@ -1046,6 +1083,7 @@
     function openAdminSettings() {
       setAdminScreen("settings");
       renderAdminSettingsSkeleton();
+      loadAdminAccountSettings();
       loadAdminScorecards();
       ensureAdminHouseholdConfigLoaded()
         .then(() => loadAdminSettings())
@@ -1089,7 +1127,8 @@
       const userRow = await lookupAdminUserRow(session.user.id);
       if (userRow && userRow.household_id) {
         adminCurrentHouseholdId = userRow.household_id;
-        adminCurrentUser = { displayName: userRow.display_name, householdId: userRow.household_id };
+        adminCurrentUser = buildAdminCurrentUser(session.user.id, userRow);
+        applyAdminTheme(adminCurrentUser.preferences?.admin_theme);
       }
 
       const loginScreen = document.getElementById("admin-login-screen");

--- a/js/admin-core.js
+++ b/js/admin-core.js
@@ -1142,6 +1142,7 @@
     function startAdminUI() {
       if (adminUiStarted) return;
       adminUiStarted = true;
+      applyAdminTheme(adminCurrentUser?.preferences?.admin_theme);
       setAdminScreen("todos");
       adminNavButtons.forEach((button) => button.addEventListener("click", handleAdminNavClick));
       adminActiveList.addEventListener("click", handleAdminActiveListClick);
@@ -1200,6 +1201,7 @@
       initSettingsListeners();
       ensureAdminHouseholdConfigLoaded()
         .then(() => {
+          markAdminLoadSynced();
           loadAdminTodos();
           if (adminScreen === "settings") {
             loadAdminSettings();

--- a/js/admin-core.js
+++ b/js/admin-core.js
@@ -74,12 +74,10 @@
         } catch {}
         adminCurrentHouseholdId = DISPLAY_HOUSEHOLD_ID;
         adminCurrentUser = null;
-        applyAdminTheme("warm");
         throw new Error("Account not found in household");
       }
       adminCurrentHouseholdId = userRow.household_id;
       adminCurrentUser = buildAdminCurrentUser(data.user.id, userRow);
-      applyAdminTheme(adminCurrentUser.preferences?.admin_theme);
       return adminCurrentUser;
     }
 
@@ -1128,7 +1126,6 @@
       if (userRow && userRow.household_id) {
         adminCurrentHouseholdId = userRow.household_id;
         adminCurrentUser = buildAdminCurrentUser(session.user.id, userRow);
-        applyAdminTheme(adminCurrentUser.preferences?.admin_theme);
       }
 
       const loginScreen = document.getElementById("admin-login-screen");

--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -34,11 +34,6 @@
         display_settings: ds
       };
 
-      // Apply the color scheme in admin mode too
-      if (typeof applyColorScheme === "function") {
-        applyColorScheme(adminHouseholdSettings.color_scheme);
-      }
-
       return adminHouseholdSettings;
     }
 
@@ -218,7 +213,32 @@
       }).join("");
     }
 
+    function loadAdminAccountSettings() {
+      const accountNameEl = document.getElementById("settings-account-name");
+      const displayNameInput = document.getElementById("settings-display-name");
+      const adminTheme = normalizeAdminTheme(adminCurrentUser?.preferences?.admin_theme);
+
+      if (accountNameEl && adminCurrentUser && adminCurrentUser.displayName) {
+        accountNameEl.textContent = `Signed in as ${adminCurrentUser.displayName}`;
+      } else if (accountNameEl) {
+        accountNameEl.textContent = "";
+      }
+
+      if (displayNameInput) {
+        displayNameInput.value = adminCurrentUser?.displayName || "";
+      }
+
+      const themeRadio = document.querySelector(`[name="admin_theme"][value="${adminTheme}"]`);
+      if (themeRadio) {
+        themeRadio.checked = true;
+      }
+
+      updateAdminLastSyncedLabel();
+    }
+
     function loadAdminSettings() {
+      loadAdminAccountSettings();
+
       const ds = adminHouseholdSettings.display_settings || {};
       const configurableScreens = getAdminConfigurableScreens();
       const activeScreens = Array.isArray(ds.active_screens) ? ds.active_screens : configurableScreens;
@@ -269,17 +289,6 @@
 
       // Google Cal ID
       if (calIdInput) calIdInput.value = adminHouseholdSettings.google_cal_id || "";
-
-      // Last synced
-      updateAdminLastSyncedLabel();
-
-      // Account
-      const accountNameEl = document.getElementById("settings-account-name");
-      if (accountNameEl && adminCurrentUser && adminCurrentUser.displayName) {
-        accountNameEl.textContent = `Signed in as ${adminCurrentUser.displayName}`;
-      } else if (accountNameEl) {
-        accountNameEl.textContent = "";
-      }
 
       renderDisplayPairingCard();
       loadActiveDisplayPairing();
@@ -458,9 +467,6 @@
         } else {
           adminHouseholdSettings.display_settings = newDs;
           adminHouseholdSettings.color_scheme = colorScheme;
-          if (typeof applyColorScheme === "function") {
-            applyColorScheme(colorScheme);
-          }
           showToast("Display settings saved.");
         }
       } finally {
@@ -500,6 +506,59 @@
         }
       } finally {
         integrationsSavePending = false;
+        if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = "Save"; }
+      }
+    }
+
+    async function saveAccountSection() {
+      const client = getSupabaseClient();
+      if (!client) {
+        showToast(friendlySaveMessage());
+        return;
+      }
+      if (accountSavePending || !adminCurrentUser?.id) return;
+
+      accountSavePending = true;
+      const saveBtn = document.getElementById("settings-account-save");
+      if (saveBtn) { saveBtn.disabled = true; saveBtn.textContent = "Saving\u2026"; }
+
+      try {
+        const displayNameInput = document.getElementById("settings-display-name");
+        const nextDisplayName = displayNameInput ? displayNameInput.value.trim() : "";
+        const adminThemeRadio = document.querySelector("[name='admin_theme']:checked");
+        const nextAdminTheme = normalizeAdminTheme(adminThemeRadio ? adminThemeRadio.value : "warm");
+        const nextPreferences = {
+          ...(adminCurrentUser?.preferences || {}),
+          admin_theme: nextAdminTheme
+        };
+
+        const { data, error } = await client
+          .from("users")
+          .update({
+            display_name: nextDisplayName || null,
+            preferences: nextPreferences
+          })
+          .eq("id", adminCurrentUser.id)
+          .select("display_name, preferences")
+          .single();
+
+        if (error || !data) {
+          showToast(friendlySaveMessage());
+        } else {
+          adminCurrentUser = {
+            ...adminCurrentUser,
+            displayName: data.display_name || "",
+            preferences: {
+              ...(data.preferences && typeof data.preferences === "object" ? data.preferences : {}),
+              admin_theme: normalizeAdminTheme(data.preferences?.admin_theme)
+            }
+          };
+          applyAdminTheme(adminCurrentUser.preferences.admin_theme);
+          loadAdminAccountSettings();
+          showToast("Account settings saved.");
+        }
+      } finally {
+        accountSavePending = false;
         if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = "Save"; }
       }
     }
@@ -702,6 +761,9 @@
 
       const integrationsSave = document.getElementById("settings-integrations-save");
       if (integrationsSave) integrationsSave.addEventListener("click", saveIntegrationsSection);
+
+      const accountSave = document.getElementById("settings-account-save");
+      if (accountSave) accountSave.addEventListener("click", saveAccountSection);
 
       const pairingGenerate = document.getElementById("settings-display-pairing-generate");
       if (pairingGenerate) pairingGenerate.addEventListener("click", generateDisplayPairing);

--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -301,6 +301,11 @@
       el.textContent = label === "Never synced" ? label : `Last synced ${label}`;
     }
 
+    function markAdminLoadSynced() {
+      localStorage.setItem(LAST_SYNCED_KEY, new Date().toISOString());
+      updateAdminLastSyncedLabel();
+    }
+
     async function refreshAdminData() {
       await Promise.allSettled([
         loadAdminTodos(),

--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -642,8 +642,7 @@
         }
 
         await refreshAdminData();
-        localStorage.setItem(LAST_SYNCED_KEY, new Date().toISOString());
-        updateAdminLastSyncedLabel();
+        markAdminLoadSynced();
         showToast("Sync complete.");
       } finally {
         adminSyncing = false;

--- a/js/display-rsvp.js
+++ b/js/display-rsvp.js
@@ -1,5 +1,51 @@
+    async function fetchDisplayWeddingSnapshot() {
+      const initialSnapshot = await fetchWeddingRsvpSnapshot();
+      if ((initialSnapshot?.stats?.totalParties || 0) > 0) {
+        return initialSnapshot;
+      }
+
+      const client = getSupabaseClient();
+      if (!client) {
+        return initialSnapshot;
+      }
+
+      // RSVP data is global and intentionally not scoped by household.
+      const [
+        { data: activeRsvpRows, error: activeRsvpError },
+        { data: supersededRsvpRows, error: supersededRsvpError },
+        { data: partyRows, error: partyError }
+      ] = await Promise.all([
+        client
+          .from("rsvps")
+          .select("id, name, attending, guest_count, created_at, status, merged_into_party_id")
+          .eq("status", "active")
+          .order("created_at", { ascending: false }),
+        client
+          .from("rsvps")
+          .select("id, name, attending, guest_count, created_at, status, merged_into_party_id")
+          .eq("status", "superseded")
+          .order("created_at", { ascending: false }),
+        client
+          .from("invited_parties")
+          .select("id, name, invited_count, rsvp_id, created_at")
+          .order("name", { ascending: true })
+      ]);
+
+      if (
+        activeRsvpError || supersededRsvpError || partyError
+        || !Array.isArray(activeRsvpRows) || !Array.isArray(supersededRsvpRows) || !Array.isArray(partyRows)
+      ) {
+        return initialSnapshot;
+      }
+
+      return buildWeddingRsvpSnapshot(
+        [...activeRsvpRows, ...supersededRsvpRows].map(mapWeddingRsvp),
+        partyRows.map(mapInvitedParty)
+      );
+    }
+
     async function fetchWeddingSnapshotWithAutoMatch() {
-      const snapshot = await fetchWeddingRsvpSnapshot();
+      const snapshot = await fetchDisplayWeddingSnapshot();
       if (!snapshot) {
         return null;
       }

--- a/js/display-rsvp.js
+++ b/js/display-rsvp.js
@@ -1,51 +1,5 @@
-    async function fetchDisplayWeddingSnapshot() {
-      const initialSnapshot = await fetchWeddingRsvpSnapshot();
-      if ((initialSnapshot?.stats?.totalParties || 0) > 0) {
-        return initialSnapshot;
-      }
-
-      const client = getSupabaseClient();
-      if (!client) {
-        return initialSnapshot;
-      }
-
-      // RSVP data is global and intentionally not scoped by household.
-      const [
-        { data: activeRsvpRows, error: activeRsvpError },
-        { data: supersededRsvpRows, error: supersededRsvpError },
-        { data: partyRows, error: partyError }
-      ] = await Promise.all([
-        client
-          .from("rsvps")
-          .select("id, name, attending, guest_count, created_at, status, merged_into_party_id")
-          .eq("status", "active")
-          .order("created_at", { ascending: false }),
-        client
-          .from("rsvps")
-          .select("id, name, attending, guest_count, created_at, status, merged_into_party_id")
-          .eq("status", "superseded")
-          .order("created_at", { ascending: false }),
-        client
-          .from("invited_parties")
-          .select("id, name, invited_count, rsvp_id, created_at")
-          .order("name", { ascending: true })
-      ]);
-
-      if (
-        activeRsvpError || supersededRsvpError || partyError
-        || !Array.isArray(activeRsvpRows) || !Array.isArray(supersededRsvpRows) || !Array.isArray(partyRows)
-      ) {
-        return initialSnapshot;
-      }
-
-      return buildWeddingRsvpSnapshot(
-        [...activeRsvpRows, ...supersededRsvpRows].map(mapWeddingRsvp),
-        partyRows.map(mapInvitedParty)
-      );
-    }
-
     async function fetchWeddingSnapshotWithAutoMatch() {
-      const snapshot = await fetchDisplayWeddingSnapshot();
+      const snapshot = await fetchWeddingRsvpSnapshot();
       if (!snapshot) {
         return null;
       }

--- a/js/shared.js
+++ b/js/shared.js
@@ -28,7 +28,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.11";
+    const VERSION = "2.0.12";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");
@@ -1235,7 +1235,6 @@
 
       const [
         { data: activeRsvpRows, error: activeRsvpError },
-        { data: supersededRsvpRows, error: supersededRsvpError },
         { data: partyRows, error: partyError }
       ] = await Promise.all([
         client
@@ -1244,25 +1243,20 @@
           .eq("status", "active")
           .order("created_at", { ascending: false }),
         client
-          .from("rsvps")
-          .select("id, name, attending, guest_count, created_at, status, merged_into_party_id")
-          .eq("status", "superseded")
-          .order("created_at", { ascending: false }),
-        client
           .from("invited_parties")
           .select("id, name, invited_count, rsvp_id, created_at")
           .order("name", { ascending: true })
       ]);
 
       if (
-        activeRsvpError || supersededRsvpError || partyError
-        || !Array.isArray(activeRsvpRows) || !Array.isArray(supersededRsvpRows) || !Array.isArray(partyRows)
+        activeRsvpError || partyError
+        || !Array.isArray(activeRsvpRows) || !Array.isArray(partyRows)
       ) {
         return null;
       }
 
       return buildWeddingRsvpSnapshot(
-        [...activeRsvpRows, ...supersededRsvpRows].map(mapWeddingRsvp),
+        activeRsvpRows.map(mapWeddingRsvp),
         partyRows.map(mapInvitedParty)
       );
     }

--- a/js/shared.js
+++ b/js/shared.js
@@ -28,7 +28,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.10";
+    const VERSION = "2.0.11";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -28,7 +28,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.9";
+    const VERSION = "2.0.10";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -28,7 +28,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.8";
+    const VERSION = "2.0.9";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -16,7 +16,13 @@
       }
 
       try {
-        sb = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
+        sb = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY, {
+          auth: {
+            persistSession: isAdminMode,
+            autoRefreshToken: isAdminMode,
+            detectSessionInUrl: isAdminMode
+          }
+        });
       } catch(e) {
         console.warn('Supabase unavailable, running with hardcoded data.', e);
       }
@@ -28,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.12";
+    const VERSION = "2.0.13";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.8";
+const CACHE_NAME = "homeboard-v2.0.9";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.11";
+const CACHE_NAME = "homeboard-v2.0.12";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.12";
+const CACHE_NAME = "homeboard-v2.0.13";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.9";
+const CACHE_NAME = "homeboard-v2.0.10";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.10";
+const CACHE_NAME = "homeboard-v2.0.11";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary
- reorganize the admin settings screen into Household, Display, Integrations, and Account sections with the sync status moved to a subtle footer row
- add user-level account settings for display name and admin theme, saving `display_name` and `preferences.admin_theme` to `public.users`
- apply the saved admin theme on login and session restore while keeping admin theme independent from the household display color scheme

## Testing
- `node --check js/admin-core.js`
- `node --check js/admin-settings.js`

AI-assisted: Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Account settings section with display name customization and personal admin theme selection (warm, dark, or slate).
  * Integrated Display Pairing functionality into the Display settings panel.
  * Relocated sync status indicator to the Settings footer.

* **Style**
  * Restructured Settings screen layout and styling for improved organization and usability.

* **Documentation**
  * Updated documentation to reflect personal admin settings storage.

* **Chores**
  * Version updated to 2.0.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->