### PR TITLE
Add self-serve signup page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Homeboard is a household command-center PWA built for two surfaces:
 
 - a wall-mounted display at `/` that rotates through shared household info
 - a phone-friendly admin app at `/admin` for managing that household
+- a public self-serve signup page at `/signup` for new household creation with invite codes
 
 It is a plain HTML/CSS/JS app with Supabase as the backend and Netlify for hosting.
 
@@ -28,8 +29,9 @@ Both modes are served from a single `index.html`.
 |---|---|---|---|
 | Display | `/` | wall tablet | landscape |
 | Admin | `/admin` | phone | portrait |
+| Signup | `/signup` | phone | portrait |
 
-Netlify rewrites `/admin` to `index.html`, and the app decides which mode to boot from `window.location.pathname` before the main scripts run.
+Netlify rewrites `/admin` to `index.html` and `/signup` to `signup.html`. The main app decides which mode to boot from `window.location.pathname` before the main scripts run.
 
 ## Auth And Access
 
@@ -45,6 +47,16 @@ Admin mode uses Supabase Auth email/password sign-in.
 - admin reads and writes are scoped to that household
 
 If a valid Supabase auth user exists but there is no matching row in `public.users`, the app signs the user back out and blocks access.
+
+### Signup mode
+
+Signup mode is public and uses invite codes to create a new household.
+
+- the browser validates the uppercase invite code against `invite_codes`
+- it creates the auth account through `supabase.auth.signUp()`
+- it calls the `create-household-on-signup` Edge Function with the new session access token
+- after setup succeeds, it increments `invite_codes.use_count`
+- the user is redirected into `/admin?onboarding=true`
 
 ### Display mode
 
@@ -173,6 +185,7 @@ Core tables used by Homeboard:
 | `scorecards` | scorecard definitions |
 | `scorecard_sessions` | active and completed scorecard sessions |
 | `display_pairings` | temporary pairing codes for display setup |
+| `invite_codes` | self-serve household signup codes with active state and usage limits |
 | `rsvps` | wedding RSVP data; schema is treated as fixed |
 | `invited_parties` | wedding invite list and RSVP matching source of truth |
 

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/signup  /signup.html  200

--- a/css/admin.css
+++ b/css/admin.css
@@ -44,20 +44,24 @@
 
     .admin-login-brand {
       display: flex;
-      align-items: center;
-      gap: 8px;
-      font-family: "Bricolage Grotesque", Manrope, sans-serif;
-      font-size: 1.1rem;
-      font-weight: 700;
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-      color: var(--ink);
+      justify-content: center;
     }
 
-    .admin-login-brand svg {
-      width: 20px;
-      height: 20px;
-      color: var(--color-accent);
+    .admin-login-logo {
+      display: block;
+      width: 160px;
+      max-width: 100%;
+      height: auto;
+      opacity: 0.92;
+      filter: brightness(0.97);
+    }
+
+    html[data-scheme="slate"] .admin-login-logo {
+      filter: none;
+    }
+
+    html[data-scheme="dark"] .admin-login-logo {
+      filter: saturate(0) brightness(0) invert(0.93) sepia(0.22) saturate(0.7) brightness(1.02);
     }
 
     #admin-login-form {

--- a/css/admin.css
+++ b/css/admin.css
@@ -86,6 +86,19 @@
       margin-top: 4px;
     }
 
+    .admin-auth-version {
+      margin-top: 4px;
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      opacity: 0.62;
+      text-align: center;
+      text-transform: none;
+      pointer-events: none;
+      user-select: none;
+    }
+
     .admin-header-bar {
       min-height: 48px;
       display: flex;

--- a/index.html
+++ b/index.html
@@ -355,8 +355,7 @@
     <div class="admin-login-screen" id="admin-login-screen">
       <div class="admin-login-card">
         <div class="admin-login-brand">
-          <i data-lucide="sliders-horizontal"></i>
-          <span>Homeboard</span>
+          <img class="admin-login-logo" src="homeboard_logo.svg" alt="Homeboard" width="160" decoding="async">
         </div>
         <form id="admin-login-form" novalidate>
           <div class="admin-field">

--- a/index.html
+++ b/index.html
@@ -370,6 +370,7 @@
           </div>
           <div class="admin-login-error" id="admin-login-error" hidden></div>
           <button type="submit" class="admin-button admin-button--primary admin-login-submit">Sign in</button>
+          <div class="admin-auth-version" id="admin-login-version" aria-hidden="true"></div>
         </form>
       </div>
     </div>

--- a/js/admin-core.js
+++ b/js/admin-core.js
@@ -108,6 +108,8 @@
 
     function initLoginFormListeners() {
       const form = document.getElementById("admin-login-form");
+      const loginVersionEl = document.getElementById("admin-login-version");
+      if (loginVersionEl) loginVersionEl.textContent = `v${VERSION}`;
       if (!form) return;
       form.addEventListener("submit", async (e) => {
         e.preventDefault();

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.15";
+    const VERSION = "2.0.16";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.16";
+    const VERSION = "2.0.17";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.13";
+    const VERSION = "2.0.14";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.14";
+    const VERSION = "2.0.15";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "sed -i \"s|%%SUPABASE_URL%%|${SUPABASE_URL}|g; s|%%SUPABASE_KEY%%|${SUPABASE_KEY}|g; s|%%GOOGLE_CAL_KEY%%|${GOOGLE_CAL_KEY}|g; s|%%UNSPLASH_ACCESS_KEY%%|${UNSPLASH_ACCESS_KEY}|g\" js/shared.js"
+  command = "sed -i \"s|%%SUPABASE_URL%%|${SUPABASE_URL}|g; s|%%SUPABASE_KEY%%|${SUPABASE_KEY}|g; s|%%GOOGLE_CAL_KEY%%|${GOOGLE_CAL_KEY}|g; s|%%UNSPLASH_ACCESS_KEY%%|${UNSPLASH_ACCESS_KEY}|g\" js/shared.js signup.html"
   publish = "."
 
 [build.environment]

--- a/signup.html
+++ b/signup.html
@@ -77,7 +77,7 @@
       backdrop-filter: blur(14px);
     }
 
-    .signup-brand {
+    .admin-login-brand {
       display: flex;
       align-items: center;
       gap: 8px;
@@ -89,7 +89,7 @@
       color: var(--ink);
     }
 
-    .signup-brand svg {
+    .admin-login-brand svg {
       width: 20px;
       height: 20px;
       color: var(--color-accent);
@@ -222,7 +222,7 @@
 <body>
   <main class="signup-screen">
     <section class="signup-card" aria-labelledby="signup-title">
-      <div class="signup-brand" aria-label="Homeboard">
+      <div class="admin-login-brand" aria-label="Homeboard">
         <i data-lucide="sliders-horizontal"></i>
         <span>Homeboard</span>
       </div>
@@ -241,7 +241,7 @@
             autocomplete="off"
             autocapitalize="characters"
             spellcheck="false"
-            placeholder="HB-X7K2PQ"
+            placeholder="Enter your invite code"
             required
           >
         </div>
@@ -252,7 +252,7 @@
             class="admin-input"
             type="text"
             autocomplete="name"
-            placeholder="Chris"
+            placeholder="Your first name"
             required
           >
         </div>

--- a/signup.html
+++ b/signup.html
@@ -303,6 +303,7 @@
   <script>
     const SUPABASE_URL = "%%SUPABASE_URL%%";
     const SUPABASE_KEY = "%%SUPABASE_KEY%%";
+    const VERSION = "2.0.17";
     const pathname = window.location.pathname.replace(/\/+$/, "") || "/";
     const isAuthMode = pathname === "/admin" || pathname === "/signup";
     let sb = null;

--- a/signup.html
+++ b/signup.html
@@ -79,21 +79,16 @@
 
     .admin-login-brand {
       display: flex;
-      align-items: center;
-      gap: 8px;
-      font-family: "Bricolage Grotesque", Manrope, sans-serif;
-      font-size: 1.1rem;
-      font-weight: 700;
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-      color: var(--ink);
+      justify-content: center;
     }
 
-    .admin-login-brand svg {
-      width: 20px;
-      height: 20px;
-      color: var(--color-accent);
-      flex-shrink: 0;
+    .admin-login-logo {
+      display: block;
+      width: 160px;
+      max-width: 100%;
+      height: auto;
+      opacity: 0.92;
+      filter: brightness(0.97);
     }
 
     .signup-copy {
@@ -223,8 +218,7 @@
   <main class="signup-screen">
     <section class="signup-card" aria-labelledby="signup-title">
       <div class="admin-login-brand" aria-label="Homeboard">
-        <i data-lucide="sliders-horizontal"></i>
-        <span>Homeboard</span>
+        <img class="admin-login-logo" src="homeboard_logo.svg" alt="Homeboard" width="160" decoding="async">
       </div>
       <div class="signup-copy">
         <h1 class="signup-title" id="signup-title">Create your household</h1>

--- a/signup.html
+++ b/signup.html
@@ -155,6 +155,11 @@
       letter-spacing: 0.08em;
     }
 
+    .signup-code-input::placeholder {
+      letter-spacing: normal;
+      text-transform: none;
+    }
+
     .admin-login-error {
       background: rgba(166, 76, 99, 0.12);
       border: 1px solid rgba(166, 76, 99, 0.28);
@@ -201,6 +206,19 @@
       width: 100%;
       justify-content: center;
       margin-top: 4px;
+    }
+
+    .signup-version {
+      margin-top: 4px;
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      opacity: 0.62;
+      text-align: center;
+      text-transform: none;
+      pointer-events: none;
+      user-select: none;
     }
 
     @media (max-width: 480px) {
@@ -275,6 +293,7 @@
         </div>
         <div class="admin-login-error" id="signup-error" hidden role="alert"></div>
         <button class="admin-button admin-button--primary signup-submit" id="signup-submit" type="submit">Create account</button>
+        <div class="signup-version" id="signup-version" aria-hidden="true"></div>
       </form>
     </section>
   </main>
@@ -532,6 +551,11 @@
     function initSignupPage() {
       if (window.lucide && typeof window.lucide.createIcons === "function") {
         window.lucide.createIcons();
+      }
+
+      const signupVersionEl = document.getElementById("signup-version");
+      if (signupVersionEl) {
+        signupVersionEl.textContent = `v${VERSION}`;
       }
 
       prefillInviteCodeFromUrl();

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,559 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#F5F0E8">
+  <title>Homeboard Sign Up</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,700;12..96,800&family=Fraunces:opsz,wght@9..144,600;9..144,700&family=Manrope:wght@400;500;600;700;800&family=Righteous&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #f5f0e8;
+      --bg-soft: #fbf7f1;
+      --panel: rgba(255, 252, 246, 0.86);
+      --panel-strong: rgba(255, 250, 242, 0.96);
+      --ink: #30261d;
+      --muted: #796a5e;
+      --border: rgba(124, 96, 69, 0.18);
+      --amber: #b45309;
+      --amber-soft: #f7d9aa;
+      --color-accent: #b45309;
+      --color-accent-subtle: #f7d9aa;
+      --color-text-on-accent: #ffffff;
+      --sage: #15803d;
+      --sage-soft: #dcefdc;
+      --rose: #a64c63;
+      --rose-soft: #f8dce3;
+      --shadow: 0 18px 44px rgba(98, 73, 46, 0.12);
+      --radius-lg: 28px;
+      --radius-md: 22px;
+      --radius-sm: 16px;
+      --button-radius: 8px;
+      --tag-radius: 12px;
+      --transition: 560ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      margin: 0;
+      min-height: 100%;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: "Manrope", sans-serif;
+    }
+
+    body {
+      background-image:
+        radial-gradient(circle at top left, rgba(244, 196, 125, 0.26), transparent 28%),
+        radial-gradient(circle at top right, rgba(21, 128, 61, 0.12), transparent 30%),
+        linear-gradient(135deg, #f8f4ed 0%, #f5f0e8 44%, #efe7db 100%);
+    }
+
+    .signup-screen {
+      min-height: 100dvh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px 16px;
+    }
+
+    .signup-card {
+      width: 100%;
+      max-width: 420px;
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+      padding: 32px 24px 28px;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(14px);
+    }
+
+    .signup-brand {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-family: "Bricolage Grotesque", Manrope, sans-serif;
+      font-size: 1.1rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--ink);
+    }
+
+    .signup-brand svg {
+      width: 20px;
+      height: 20px;
+      color: var(--color-accent);
+      flex-shrink: 0;
+    }
+
+    .signup-copy {
+      display: grid;
+      gap: 8px;
+    }
+
+    .signup-title {
+      margin: 0;
+      font-family: "Bricolage Grotesque", Manrope, sans-serif;
+      font-size: clamp(1.7rem, 6vw, 2.1rem);
+      line-height: 1;
+      font-weight: 700;
+      letter-spacing: -0.03em;
+    }
+
+    .signup-note {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.98rem;
+      line-height: 1.5;
+    }
+
+    .signup-form {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .admin-field {
+      display: grid;
+      gap: 6px;
+    }
+
+    .admin-field label {
+      font-size: 0.88rem;
+      font-weight: 800;
+      color: var(--muted);
+    }
+
+    .admin-input {
+      width: 100%;
+      min-width: 0;
+      border: 1px solid rgba(124, 96, 69, 0.16);
+      border-radius: 16px;
+      padding: 14px 16px;
+      background: rgba(255, 255, 255, 0.84);
+      color: var(--ink);
+      font: inherit;
+    }
+
+    .admin-input::placeholder {
+      color: rgba(121, 106, 94, 0.72);
+    }
+
+    .admin-input:focus-visible {
+      outline: 2px solid rgba(180, 83, 9, 0.22);
+      outline-offset: 2px;
+      border-color: rgba(180, 83, 9, 0.3);
+    }
+
+    .signup-code-input {
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .admin-login-error {
+      background: rgba(166, 76, 99, 0.12);
+      border: 1px solid rgba(166, 76, 99, 0.28);
+      border-radius: var(--button-radius);
+      color: var(--rose);
+      font-size: 0.82rem;
+      padding: 10px 12px;
+      line-height: 1.45;
+    }
+
+    .admin-button {
+      border: 0;
+      border-radius: var(--button-radius);
+      padding: 12px 16px;
+      font: inherit;
+      font-weight: 800;
+      cursor: pointer;
+      transition: transform 140ms ease, opacity 140ms ease, background-color 140ms ease;
+    }
+
+    .admin-button:hover,
+    .admin-button:focus-visible {
+      transform: translateY(-1px);
+    }
+
+    .admin-button:focus-visible {
+      outline: 3px solid var(--ink);
+      outline-offset: 3px;
+      box-shadow: 0 0 0 3px rgba(255, 252, 246, 0.96);
+    }
+
+    .admin-button:disabled {
+      cursor: wait;
+      opacity: 0.6;
+      transform: none;
+    }
+
+    .admin-button--primary {
+      background: var(--color-accent);
+      color: var(--color-text-on-accent);
+    }
+
+    .signup-submit {
+      width: 100%;
+      justify-content: center;
+      margin-top: 4px;
+    }
+
+    @media (max-width: 480px) {
+      .signup-card {
+        padding: 28px 20px 24px;
+      }
+
+      .signup-submit {
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="signup-screen">
+    <section class="signup-card" aria-labelledby="signup-title">
+      <div class="signup-brand" aria-label="Homeboard">
+        <i data-lucide="sliders-horizontal"></i>
+        <span>Homeboard</span>
+      </div>
+      <div class="signup-copy">
+        <h1 class="signup-title" id="signup-title">Create your household</h1>
+        <p class="signup-note">Use your invite code to set up your Homeboard account and jump straight into Admin Mode.</p>
+      </div>
+      <form class="signup-form" id="signup-form" novalidate>
+        <div class="admin-field">
+          <label for="invite-code">Invite code</label>
+          <input
+            id="invite-code"
+            class="admin-input signup-code-input"
+            type="text"
+            inputmode="text"
+            autocomplete="off"
+            autocapitalize="characters"
+            spellcheck="false"
+            placeholder="HB-X7K2PQ"
+            required
+          >
+        </div>
+        <div class="admin-field">
+          <label for="display-name">Your name</label>
+          <input
+            id="display-name"
+            class="admin-input"
+            type="text"
+            autocomplete="name"
+            placeholder="Chris"
+            required
+          >
+        </div>
+        <div class="admin-field">
+          <label for="email">Email</label>
+          <input
+            id="email"
+            class="admin-input"
+            type="email"
+            autocomplete="email"
+            placeholder="you@example.com"
+            required
+          >
+        </div>
+        <div class="admin-field">
+          <label for="password">Password</label>
+          <input
+            id="password"
+            class="admin-input"
+            type="password"
+            autocomplete="new-password"
+            minlength="8"
+            placeholder="At least 8 characters"
+            required
+          >
+        </div>
+        <div class="admin-login-error" id="signup-error" hidden role="alert"></div>
+        <button class="admin-button admin-button--primary signup-submit" id="signup-submit" type="submit">Create account</button>
+      </form>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/lucide@latest/dist/umd/lucide.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer crossorigin="anonymous"></script>
+  <script>
+    const SUPABASE_URL = "%%SUPABASE_URL%%";
+    const SUPABASE_KEY = "%%SUPABASE_KEY%%";
+    const pathname = window.location.pathname.replace(/\/+$/, "") || "/";
+    const isAuthMode = pathname === "/admin" || pathname === "/signup";
+    let sb = null;
+
+    function initSupabaseClient() {
+      if (sb) {
+        return sb;
+      }
+
+      if (!window.supabase || typeof window.supabase.createClient !== "function") {
+        return null;
+      }
+
+      try {
+        sb = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY, {
+          auth: {
+            persistSession: isAuthMode,
+            autoRefreshToken: isAuthMode,
+            detectSessionInUrl: isAuthMode
+          }
+        });
+      } catch (error) {
+        console.warn("Supabase unavailable during signup.", error);
+      }
+
+      return sb;
+    }
+
+    function getSupabaseClient() {
+      return sb || initSupabaseClient();
+    }
+
+    function normalizeInviteCode(value) {
+      return String(value || "").trim().toUpperCase();
+    }
+
+    function showError(message) {
+      const errorEl = document.getElementById("signup-error");
+      if (!errorEl) {
+        return;
+      }
+
+      errorEl.textContent = message;
+      errorEl.hidden = false;
+    }
+
+    function clearError() {
+      const errorEl = document.getElementById("signup-error");
+      if (!errorEl) {
+        return;
+      }
+
+      errorEl.hidden = true;
+      errorEl.textContent = "";
+    }
+
+    function setSubmitting(isSubmitting) {
+      const submitButton = document.getElementById("signup-submit");
+      if (!submitButton) {
+        return;
+      }
+
+      submitButton.disabled = isSubmitting;
+      submitButton.textContent = isSubmitting ? "Creating account…" : "Create account";
+    }
+
+    function mapSignupError(error) {
+      const message = String(error?.message || "").toLowerCase();
+      if (message.includes("user already registered")) {
+        return "An account with that email already exists.";
+      }
+      if (message.includes("password should be at least 6 characters")) {
+        return "Please choose a password at least 8 characters long.";
+      }
+      return "Something went wrong. Please try again.";
+    }
+
+    async function loadInviteCodeRecord(client, code) {
+      const { data, error } = await client
+        .from("invite_codes")
+        .select("code, use_count, max_uses")
+        .eq("code", code)
+        .eq("is_active", true)
+        .maybeSingle();
+
+      if (error) {
+        throw error;
+      }
+
+      if (!data) {
+        return null;
+      }
+
+      const useCount = Number(data.use_count || 0);
+      const maxUses = Number(data.max_uses);
+
+      if (!Number.isFinite(maxUses) || useCount >= maxUses) {
+        return null;
+      }
+
+      return {
+        code: data.code,
+        useCount,
+        maxUses
+      };
+    }
+
+    async function createHousehold(accessToken, displayName) {
+      const response = await fetch(`${SUPABASE_URL}/functions/v1/create-household-on-signup`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ display_name: displayName })
+      });
+
+      if (!response.ok) {
+        throw new Error("create-household-failed");
+      }
+    }
+
+    async function incrementInviteCodeUseCount(client, inviteCode, currentUseCount) {
+      const { error } = await client
+        .from("invite_codes")
+        .update({ use_count: currentUseCount + 1 })
+        .eq("code", inviteCode);
+
+      if (error) {
+        throw error;
+      }
+    }
+
+    function prefillInviteCodeFromUrl() {
+      const inviteInput = document.getElementById("invite-code");
+      if (!inviteInput) {
+        return;
+      }
+
+      const params = new URLSearchParams(window.location.search);
+      const code = normalizeInviteCode(params.get("code"));
+      if (code) {
+        inviteInput.value = code;
+      }
+    }
+
+    function initErrorReset() {
+      const fields = Array.from(document.querySelectorAll("#signup-form input"));
+      fields.forEach((field) => {
+        field.addEventListener("input", () => {
+          if (field.id === "invite-code") {
+            const start = field.selectionStart;
+            const end = field.selectionEnd;
+            field.value = normalizeInviteCode(field.value);
+            if (typeof start === "number" && typeof end === "number") {
+              field.setSelectionRange(start, end);
+            }
+          }
+          clearError();
+        });
+      });
+    }
+
+    async function handleSignupSubmit(event) {
+      event.preventDefault();
+      clearError();
+
+      const client = getSupabaseClient();
+      if (!client) {
+        showError("Something went wrong. Please try again.");
+        return;
+      }
+
+      const inviteInput = document.getElementById("invite-code");
+      const nameInput = document.getElementById("display-name");
+      const emailInput = document.getElementById("email");
+      const passwordInput = document.getElementById("password");
+
+      const inviteCode = normalizeInviteCode(inviteInput?.value);
+      const displayName = String(nameInput?.value || "").trim();
+      const email = String(emailInput?.value || "").trim();
+      const password = String(passwordInput?.value || "");
+
+      if (inviteInput) {
+        inviteInput.value = inviteCode;
+      }
+
+      if (!inviteCode || !displayName || !email || !password) {
+        showError("Please fill out all fields.");
+        return;
+      }
+
+      if (password.length < 8) {
+        showError("Please choose a password at least 8 characters long.");
+        return;
+      }
+
+      setSubmitting(true);
+
+      try {
+        const inviteRecord = await loadInviteCodeRecord(client, inviteCode);
+        if (!inviteRecord) {
+          showError("This invite code isn't valid or has already been used.");
+          return;
+        }
+
+        const { data, error } = await client.auth.signUp({
+          email,
+          password
+        });
+
+        if (error) {
+          showError(mapSignupError(error));
+          return;
+        }
+
+        const accessToken = data?.session?.access_token;
+        if (!accessToken) {
+          showError("Something went wrong setting up your household. Please contact support.");
+          return;
+        }
+
+        try {
+          await createHousehold(accessToken, displayName);
+        } catch (error) {
+          console.error("Household setup failed.", error);
+          showError("Something went wrong setting up your household. Please contact support.");
+          return;
+        }
+
+        try {
+          await incrementInviteCodeUseCount(client, inviteCode, inviteRecord.useCount);
+        } catch (error) {
+          console.error("Invite code use_count update failed.", error);
+        }
+
+        window.location.replace("/admin?onboarding=true");
+      } catch (error) {
+        console.error("Signup failed.", error);
+        showError("Something went wrong. Please try again.");
+      } finally {
+        setSubmitting(false);
+      }
+    }
+
+    function initSignupPage() {
+      if (window.lucide && typeof window.lucide.createIcons === "function") {
+        window.lucide.createIcons();
+      }
+
+      prefillInviteCodeFromUrl();
+      initErrorReset();
+
+      const form = document.getElementById("signup-form");
+      if (form) {
+        form.addEventListener("submit", handleSignupSubmit);
+      }
+    }
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", initSignupPage, { once: true });
+    } else {
+      initSignupPage();
+    }
+  </script>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.16";
+const CACHE_NAME = "homeboard-v2.0.17";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.14";
+const CACHE_NAME = "homeboard-v2.0.15";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.15";
+const CACHE_NAME = "homeboard-v2.0.16";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,8 @@
-const CACHE_NAME = "homeboard-v2.0.13";
+const CACHE_NAME = "homeboard-v2.0.14";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",
+  "./signup.html",
   "./manifest.json",
   "./manifest-admin.json",
   "./homeboard_logo.svg",


### PR DESCRIPTION
## Summary
- add a standalone \/signup page for invite-code household signup
- wire the page into Netlify redirects and build-time env injection
- document the signup route and bump the app/service-worker version

## Validation
- parsed the inline signup.html script with node

AI-assisted: Codex