### PR TITLE
Add admin onboarding wizard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,3 +163,7 @@ All Edge Functions on this project must be deployed with `verify_jwt = false`.
 This project uses ES256 asymmetric JWT signing. Supabase's built-in JWT verifier only supports HS256 and will reject all requests with `UNAUTHORIZED_UNSUPPORTED_TOKEN_ALGORITHM` if `verify_jwt = true`.
 
 Functions handle JWT decoding directly in their own code using the `decodeJwtFromHeader` pattern. Do not deploy any Edge Function on this project with `verify_jwt = true`. Each function's directory should contain a `config.toml` with `verify_jwt = false`.
+
+## Pull Request drafts
+
+Always open new PRs as drafts (`--draft` flag with `gh pr create`). This prevents CodeRabbit from auto-triggering a review before the work is ready. Only mark a PR ready for review when explicitly instructed to do so.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,3 +190,7 @@ Functions handle JWT decoding directly in their own code using the `decodeJwtFro
 - **Household members → users table**: `display_settings.members` currently stores the member list. Migrate to the `users` table when multi-user auth is implemented.
 - **Multiple Google Calendars**: the Integrations settings panel has a code comment noting this. When implementing, each calendar will need an ID and an enabled toggle stored in `display_settings`.
 - **Recurring to-dos**: planned for a future PR; requires a schema change to the `todos` table.
+
+## Pull Request drafts
+
+Always open new PRs as drafts (`--draft` flag with `gh pr create`). This prevents CodeRabbit from auto-triggering a review before the work is ready. Only mark a PR ready for review when explicitly instructed to do so.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Signup mode is public and uses invite codes to create a new household.
 - it calls the `create-household-on-signup` Edge Function with the new session access token
 - after setup succeeds, it increments `invite_codes.use_count`
 - the user is redirected into `/admin?onboarding=true`
+- the first admin session opens a 3-step onboarding overlay that adds household members, picks a display theme, and marks `users.preferences.onboarding_complete`
 
 ### Display mode
 
@@ -115,6 +116,7 @@ Display screens rotate automatically using timers from `display_settings.timer_i
 - manage weekly meals and meal notes
 - manage countdowns and countdown images
 - manage display settings
+- run or relaunch the onboarding intro tour from Settings
 - generate display pairing codes
 - manage RSVP review and guest list workflows
 - create and run scorecards
@@ -177,6 +179,7 @@ Core tables used by Homeboard:
 | Table | Purpose |
 |---|---|
 | `households` | household-level settings such as assistant name, color scheme, Google Calendar ID, and `display_settings` |
+| `household_members` | canonical list of household people created during signup and onboarding |
 | `users` | maps authenticated Supabase users to a household and role, and stores personal admin settings such as `display_name` and `preferences.admin_theme` |
 | `todos` | household to-dos; never hard-deleted |
 | `meal_plan` | weekly meal entries |

--- a/css/admin.css
+++ b/css/admin.css
@@ -2279,6 +2279,303 @@
       margin-top: 10px;
     }
 
+    .admin-onboarding {
+      position: fixed;
+      inset: 0;
+      z-index: 60;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px 16px calc(24px + env(safe-area-inset-bottom));
+    }
+
+    .admin-onboarding[hidden] {
+      display: none;
+    }
+
+    .admin-onboarding-backdrop {
+      position: absolute;
+      inset: 0;
+      background:
+        linear-gradient(180deg, rgba(48, 38, 29, 0.08), rgba(48, 38, 29, 0.22)),
+        rgba(245, 240, 232, 0.82);
+      backdrop-filter: blur(16px);
+    }
+
+    .admin-onboarding-shell {
+      position: relative;
+      width: min(100%, 520px);
+      max-height: min(100%, 760px);
+      display: flex;
+    }
+
+    .admin-onboarding-card {
+      position: relative;
+      width: 100%;
+      display: grid;
+      gap: 20px;
+      padding: 24px;
+      background: var(--panel-strong);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow);
+      overflow: hidden auto;
+    }
+
+    .admin-onboarding-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .admin-onboarding-step {
+      margin: 0;
+      font-size: 0.78rem;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .admin-onboarding-close {
+      margin: -6px -6px 0 0;
+      flex-shrink: 0;
+    }
+
+    .admin-onboarding-body {
+      display: grid;
+      gap: 18px;
+    }
+
+    .admin-onboarding-copy {
+      display: grid;
+      gap: 8px;
+    }
+
+    .admin-onboarding-title {
+      margin: 0;
+      font-family: "Bricolage Grotesque", Manrope, sans-serif;
+      font-size: clamp(1.7rem, 6vw, 2.2rem);
+      line-height: 1.05;
+      letter-spacing: -0.03em;
+    }
+
+    .admin-onboarding-note {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.55;
+    }
+
+    .admin-onboarding-members {
+      display: grid;
+      gap: 10px;
+    }
+
+    .admin-onboarding-member-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .admin-onboarding-member-row .admin-input {
+      min-height: 48px;
+    }
+
+    .admin-onboarding-member-row--locked {
+      grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    .admin-onboarding-member-lock {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 72px;
+      padding: 0 14px;
+      border-radius: var(--button-radius);
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.72);
+      color: var(--muted);
+      font-size: 0.84rem;
+      font-weight: 700;
+      min-height: 48px;
+    }
+
+    .admin-onboarding-link-button {
+      justify-self: flex-start;
+      border: none;
+      background: none;
+      padding: 0;
+      color: var(--color-accent);
+      font: inherit;
+      font-weight: 800;
+      cursor: pointer;
+    }
+
+    .admin-onboarding-link-button:hover,
+    .admin-onboarding-link-button:focus-visible {
+      text-decoration: underline;
+    }
+
+    .admin-onboarding-theme-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .admin-onboarding-theme-card {
+      display: grid;
+      gap: 12px;
+      padding: 14px;
+      text-align: left;
+      border-radius: var(--tag-radius);
+      border: 2px solid rgba(124, 96, 69, 0.12);
+      background: rgba(255, 255, 255, 0.74);
+      color: inherit;
+      cursor: pointer;
+      transition: border-color 120ms ease, transform 120ms ease, background-color 120ms ease;
+    }
+
+    .admin-onboarding-theme-card:hover,
+    .admin-onboarding-theme-card:focus-visible {
+      transform: translateY(-1px);
+    }
+
+    .admin-onboarding-theme-card:focus-visible {
+      outline: 3px solid rgba(180, 83, 9, 0.28);
+      outline-offset: 2px;
+    }
+
+    .admin-onboarding-theme-card.is-selected {
+      border-color: var(--color-accent);
+      background: color-mix(in srgb, var(--color-accent-subtle) 54%, transparent);
+    }
+
+    .admin-onboarding-theme-preview {
+      display: grid;
+      gap: 8px;
+      min-height: 88px;
+      padding: 12px;
+      border-radius: 14px;
+      border: 1px solid rgba(0, 0, 0, 0.08);
+      background: var(--onboarding-theme-bg);
+      color: var(--onboarding-theme-ink);
+    }
+
+    .admin-onboarding-theme-preview::before,
+    .admin-onboarding-theme-preview::after {
+      content: "";
+      border-radius: 999px;
+      background: currentColor;
+      opacity: 0.18;
+    }
+
+    .admin-onboarding-theme-preview::before {
+      width: 44px;
+      height: 10px;
+    }
+
+    .admin-onboarding-theme-preview::after {
+      width: 72px;
+      height: 10px;
+    }
+
+    .admin-onboarding-theme-card[data-theme="warm"] {
+      --onboarding-theme-bg: #f5f0e8;
+      --onboarding-theme-ink: #30261d;
+    }
+
+    .admin-onboarding-theme-card[data-theme="dark"] {
+      --onboarding-theme-bg: #241f1c;
+      --onboarding-theme-ink: #f7efe6;
+    }
+
+    .admin-onboarding-theme-card[data-theme="slate"] {
+      --onboarding-theme-bg: #475569;
+      --onboarding-theme-ink: #f8fafc;
+    }
+
+    .admin-onboarding-theme-name {
+      font-weight: 800;
+      font-size: 0.98rem;
+    }
+
+    .admin-onboarding-feature-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .admin-onboarding-feature-card {
+      display: grid;
+      gap: 10px;
+      padding: 14px;
+      border-radius: var(--tag-radius);
+      background: rgba(255, 255, 255, 0.72);
+      border: 1px solid rgba(124, 96, 69, 0.12);
+    }
+
+    .admin-onboarding-feature-icon {
+      width: 40px;
+      height: 40px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--button-radius);
+      background: color-mix(in srgb, var(--color-accent-subtle) 64%, transparent);
+      color: var(--color-accent);
+    }
+
+    .admin-onboarding-feature-icon svg {
+      width: 20px;
+      height: 20px;
+    }
+
+    .admin-onboarding-feature-title {
+      margin: 0;
+      font-size: 0.98rem;
+      font-weight: 800;
+      color: var(--ink);
+    }
+
+    .admin-onboarding-feature-copy {
+      margin: 0;
+      font-size: 0.88rem;
+      line-height: 1.5;
+      color: var(--muted);
+    }
+
+    .admin-onboarding-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      margin-top: 4px;
+    }
+
+    .admin-onboarding-actions .admin-button {
+      min-height: 46px;
+    }
+
+    .admin-onboarding-actions-group {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-left: auto;
+    }
+
+    .admin-onboarding-error {
+      margin: 0;
+      padding: 10px 12px;
+      border-radius: var(--button-radius);
+      background: rgba(166, 76, 99, 0.12);
+      border: 1px solid rgba(166, 76, 99, 0.2);
+      color: var(--rose);
+      font-size: 0.82rem;
+      line-height: 1.45;
+    }
+
     /* End-aligned actions row */
     .admin-actions--end {
       justify-content: flex-end;
@@ -2302,6 +2599,36 @@
       .admin-settings-footer-sync {
         gap: 8px;
       }
+
+      .admin-onboarding {
+        padding: 14px 12px calc(14px + env(safe-area-inset-bottom));
+      }
+
+      .admin-onboarding-card {
+        padding: 20px 18px 18px;
+      }
+
+      .admin-onboarding-theme-grid,
+      .admin-onboarding-feature-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .admin-onboarding-actions,
+      .admin-onboarding-actions-group {
+        width: 100%;
+        flex-wrap: wrap;
+      }
+
+      .admin-onboarding-actions .admin-button,
+      .admin-onboarding-actions-group .admin-button {
+        flex: 1 1 0;
+      }
+
+      .admin-onboarding-actions .admin-button:only-child,
+      .admin-onboarding-actions-group .admin-button:only-child {
+        width: 100%;
+        flex-basis: 100%;
+      }
     }
 
     html[data-scheme="dark"] .admin-header-bar,
@@ -2317,6 +2644,34 @@
     html[data-scheme="dark"] .admin-display-pairing-card {
       background: rgba(255, 255, 255, 0.06);
       border-color: rgba(255, 240, 220, 0.11);
+    }
+
+    html[data-scheme="dark"] .admin-onboarding-backdrop {
+      background:
+        linear-gradient(180deg, rgba(0, 0, 0, 0.28), rgba(0, 0, 0, 0.46)),
+        rgba(23, 20, 15, 0.74);
+    }
+
+    html[data-scheme="dark"] .admin-onboarding-card,
+    html[data-scheme="dark"] .admin-onboarding-feature-card,
+    html[data-scheme="dark"] .admin-onboarding-theme-card,
+    html[data-scheme="dark"] .admin-onboarding-member-lock {
+      background: rgba(36, 31, 28, 0.94);
+      border-color: rgba(255, 240, 220, 0.11);
+      box-shadow: 0 18px 36px rgba(0, 0, 0, 0.28);
+    }
+
+    html[data-scheme="dark"] .admin-onboarding-title,
+    html[data-scheme="dark"] .admin-onboarding-theme-name,
+    html[data-scheme="dark"] .admin-onboarding-feature-title {
+      color: var(--ink);
+    }
+
+    html[data-scheme="dark"] .admin-onboarding-note,
+    html[data-scheme="dark"] .admin-onboarding-step,
+    html[data-scheme="dark"] .admin-onboarding-feature-copy,
+    html[data-scheme="dark"] .admin-onboarding-member-lock {
+      color: #cbbeb3;
     }
 
     html[data-scheme="dark"] .admin-header-brand {

--- a/css/admin.css
+++ b/css/admin.css
@@ -2402,20 +2402,9 @@
       min-height: 48px;
     }
 
-    .admin-onboarding-link-button {
+    .admin-onboarding-add-button {
       justify-self: flex-start;
-      border: none;
-      background: none;
-      padding: 0;
-      color: var(--color-accent);
-      font: inherit;
-      font-weight: 800;
-      cursor: pointer;
-    }
-
-    .admin-onboarding-link-button:hover,
-    .admin-onboarding-link-button:focus-visible {
-      text-decoration: underline;
+      margin-top: 8px;
     }
 
     .admin-onboarding-theme-grid {
@@ -2492,8 +2481,8 @@
     }
 
     .admin-onboarding-theme-card[data-theme="slate"] {
-      --onboarding-theme-bg: #475569;
-      --onboarding-theme-ink: #f8fafc;
+      --onboarding-theme-bg: #f8fafc;
+      --onboarding-theme-ink: #334155;
     }
 
     .admin-onboarding-theme-name {

--- a/css/admin.css
+++ b/css/admin.css
@@ -29,6 +29,18 @@
       display: none !important;
     }
 
+    .admin-auth-loading {
+      min-height: 100dvh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px 16px;
+    }
+
+    .admin-auth-loading[hidden] {
+      display: none !important;
+    }
+
     .admin-login-card {
       background: var(--panel);
       border: 1px solid var(--border);
@@ -40,6 +52,12 @@
       flex-direction: column;
       gap: 24px;
       box-shadow: var(--shadow);
+    }
+
+    .admin-auth-loading-card {
+      align-items: center;
+      text-align: center;
+      max-width: 320px;
     }
 
     .admin-login-brand {
@@ -86,6 +104,57 @@
       margin-top: 4px;
     }
 
+    .admin-auth-loading-copy {
+      display: grid;
+      justify-items: center;
+      gap: 10px;
+    }
+
+    .admin-auth-loading-spinner {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      border: 3px solid color-mix(in srgb, var(--color-accent-subtle) 70%, transparent);
+      border-top-color: var(--color-accent);
+      animation: admin-auth-spin 0.9s linear infinite;
+    }
+
+    .admin-auth-loading-label {
+      margin: 0;
+      font-size: 0.95rem;
+      font-weight: 700;
+      color: var(--ink);
+    }
+
+    .admin-auth-loading-skeleton {
+      width: 100%;
+      display: grid;
+      gap: 10px;
+    }
+
+    .admin-auth-loading-bar {
+      display: block;
+      height: 10px;
+      border-radius: 999px;
+      background: linear-gradient(
+        90deg,
+        rgba(124, 96, 69, 0.1) 0%,
+        rgba(124, 96, 69, 0.2) 50%,
+        rgba(124, 96, 69, 0.1) 100%
+      );
+      background-size: 220% 100%;
+      animation: admin-auth-shimmer 1.2s ease-in-out infinite;
+    }
+
+    .admin-auth-loading-bar--wide {
+      width: 100%;
+    }
+
+    .admin-auth-loading-bar--short {
+      width: 62%;
+      justify-self: center;
+    }
+
     .admin-auth-version {
       margin-top: 4px;
       font-size: 0.7rem;
@@ -97,6 +166,21 @@
       text-transform: none;
       pointer-events: none;
       user-select: none;
+    }
+
+    @keyframes admin-auth-spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
+    @keyframes admin-auth-shimmer {
+      0% {
+        background-position: 100% 0;
+      }
+      100% {
+        background-position: -100% 0;
+      }
     }
 
     .admin-header-bar {

--- a/css/admin.css
+++ b/css/admin.css
@@ -2404,7 +2404,6 @@
 
     .admin-onboarding-add-button {
       justify-self: flex-start;
-      margin-top: 8px;
     }
 
     .admin-onboarding-theme-grid {
@@ -2554,6 +2553,44 @@
       margin-left: auto;
     }
 
+    .admin-onboarding-actions--step1 {
+      margin-top: 12px;
+      flex-wrap: nowrap;
+    }
+
+    .admin-onboarding-instruction-list {
+      margin: 0;
+      padding-left: 22px;
+      display: grid;
+      gap: 14px;
+      color: var(--ink);
+    }
+
+    .admin-onboarding-instruction-item {
+      display: grid;
+      gap: 4px;
+      line-height: 1.55;
+    }
+
+    .admin-onboarding-instruction-item strong {
+      font-size: 0.96rem;
+    }
+
+    .admin-onboarding-instruction-item span {
+      color: var(--muted);
+    }
+
+    .admin-onboarding-inline-code {
+      font-family: "Bricolage Grotesque", Manrope, sans-serif;
+      font-size: 0.92em;
+      font-weight: 700;
+      color: var(--ink);
+    }
+
+    .admin-onboarding-note--subtle {
+      font-size: 0.9rem;
+    }
+
     .admin-onboarding-error {
       margin: 0;
       padding: 10px 12px;
@@ -2608,6 +2645,16 @@
         flex-wrap: wrap;
       }
 
+      .admin-onboarding-actions--step1 {
+        justify-content: space-between;
+        flex-wrap: nowrap;
+      }
+
+      .admin-onboarding-actions--step1 .admin-button {
+        flex: 0 1 auto;
+        width: auto;
+      }
+
       .admin-onboarding-actions .admin-button,
       .admin-onboarding-actions-group .admin-button {
         flex: 1 1 0;
@@ -2659,7 +2706,8 @@
     html[data-scheme="dark"] .admin-onboarding-note,
     html[data-scheme="dark"] .admin-onboarding-step,
     html[data-scheme="dark"] .admin-onboarding-feature-copy,
-    html[data-scheme="dark"] .admin-onboarding-member-lock {
+    html[data-scheme="dark"] .admin-onboarding-member-lock,
+    html[data-scheme="dark"] .admin-onboarding-instruction-item span {
       color: #cbbeb3;
     }
 

--- a/css/admin.css
+++ b/css/admin.css
@@ -2539,7 +2539,7 @@
     .admin-onboarding-theme-preview::after {
       content: "";
       border-radius: 999px;
-      background: currentColor;
+      background: currentcolor;
       opacity: 0.18;
     }
 

--- a/index.html
+++ b/index.html
@@ -351,8 +351,25 @@
 
   <div class="admin-shell" id="admin-app" hidden>
 
+    <div class="admin-auth-loading" id="admin-auth-loading">
+      <div class="admin-login-card admin-auth-loading-card" aria-live="polite">
+        <div class="admin-login-brand">
+          <img class="admin-login-logo" src="homeboard_logo.svg" alt="Homeboard" width="160" decoding="async">
+        </div>
+        <div class="admin-auth-loading-copy">
+          <div class="admin-auth-loading-spinner" aria-hidden="true"></div>
+          <p class="admin-auth-loading-label">Opening your admin…</p>
+        </div>
+        <div class="admin-auth-loading-skeleton" aria-hidden="true">
+          <span class="admin-auth-loading-bar admin-auth-loading-bar--wide"></span>
+          <span class="admin-auth-loading-bar"></span>
+          <span class="admin-auth-loading-bar admin-auth-loading-bar--short"></span>
+        </div>
+      </div>
+    </div>
+
     <!-- Login screen — shown when no auth session -->
-    <div class="admin-login-screen" id="admin-login-screen">
+    <div class="admin-login-screen" id="admin-login-screen" hidden>
       <div class="admin-login-card">
         <div class="admin-login-brand">
           <img class="admin-login-logo" src="homeboard_logo.svg" alt="Homeboard" width="160" decoding="async">

--- a/index.html
+++ b/index.html
@@ -502,6 +502,15 @@
                   class="admin-button admin-button--primary">Save</button>
               </div>
             </div>
+
+            <div class="admin-settings-subsection">
+              <div class="admin-settings-subsection-label">Help</div>
+              <p class="admin-field-hint">Walk through the setup steps again anytime.</p>
+              <div class="admin-actions admin-actions--end">
+                <button type="button" id="settings-onboarding-tour-btn"
+                  class="admin-button admin-button--secondary">Relaunch intro tour</button>
+              </div>
+            </div>
           </div>
         </section>
 
@@ -735,6 +744,21 @@
     </div><!-- /#admin-main-content -->
   </div><!-- /#admin-app -->
 
+  <div class="admin-onboarding" id="admin-onboarding" hidden role="dialog" aria-modal="true" aria-labelledby="admin-onboarding-title">
+    <div class="admin-onboarding-backdrop" aria-hidden="true"></div>
+    <div class="admin-onboarding-shell">
+      <section class="admin-onboarding-card" aria-live="polite">
+        <div class="admin-onboarding-header">
+          <p class="admin-onboarding-step" id="admin-onboarding-step-label">Step 1 of 3</p>
+          <button class="admin-modal-close admin-onboarding-close" type="button" id="admin-onboarding-close" aria-label="Close" hidden>
+            <i data-lucide="x"></i>
+          </button>
+        </div>
+        <div class="admin-onboarding-body" id="admin-onboarding-body"></div>
+      </section>
+    </div>
+  </div>
+
   <div class="toast" id="toast" role="status" aria-live="polite"></div>
 
   <div class="admin-modal" id="admin-modal" hidden role="dialog" aria-modal="true" aria-labelledby="admin-modal-title">
@@ -803,5 +827,6 @@
   <script src="js/admin-rsvp.js" defer></script>
   <script src="js/admin-settings.js" defer></script>
   <script src="js/admin-core.js" defer></script>
+  <script src="js/admin-onboarding.js" defer></script>
 </body>
 </html>

--- a/js/admin-core.js
+++ b/js/admin-core.js
@@ -1130,12 +1130,22 @@
         return;
       }
 
+      const client = getSupabaseClient();
       const userRow = await lookupAdminUserRow(session.user.id);
-      if (userRow && userRow.household_id) {
-        adminCurrentHouseholdId = userRow.household_id;
-        adminCurrentUser = buildAdminCurrentUser(session.user.id, userRow);
+      if (!userRow?.household_id) {
+        if (client) {
+          try {
+            await client.auth.signOut();
+          } catch {}
+        }
+        adminCurrentHouseholdId = DISPLAY_HOUSEHOLD_ID;
+        adminCurrentUser = null;
+        setAdminAuthView("login");
+        return;
       }
 
+      adminCurrentHouseholdId = userRow.household_id;
+      adminCurrentUser = buildAdminCurrentUser(session.user.id, userRow);
       setAdminAuthView("main");
       startAdminUI();
     }

--- a/js/admin-core.js
+++ b/js/admin-core.js
@@ -94,10 +94,7 @@
       adminCurrentHouseholdId = DISPLAY_HOUSEHOLD_ID;
       adminCurrentUser = null;
       applyAdminTheme("warm");
-      const mainContent = document.getElementById("admin-main-content");
-      const loginScreen = document.getElementById("admin-login-screen");
-      if (mainContent) mainContent.hidden = true;
-      if (loginScreen) loginScreen.hidden = false;
+      setAdminAuthView("login");
       const errorEl = document.getElementById("admin-login-error");
       if (errorEl) { errorEl.hidden = true; errorEl.textContent = ""; }
       const emailInput = document.getElementById("admin-login-email");
@@ -124,12 +121,9 @@
           await doAdminLogin(email, password);
           const emailInput = document.getElementById("admin-login-email");
           const passwordInput = document.getElementById("admin-login-password");
-          const loginScreen = document.getElementById("admin-login-screen");
-          const mainContent = document.getElementById("admin-main-content");
           if (emailInput) emailInput.value = "";
           if (passwordInput) passwordInput.value = "";
-          if (loginScreen) loginScreen.hidden = true;
-          if (mainContent) mainContent.hidden = false;
+          setAdminAuthView("main");
           startAdminUI();
         } catch (err) {
           console.error("Admin sign-in failed.", err);
@@ -153,6 +147,16 @@
         || err?.status === 400
         || err?.status === 401
         || err?.name === "AuthApiError";
+    }
+
+    function setAdminAuthView(view) {
+      const loadingScreen = document.getElementById("admin-auth-loading");
+      const loginScreen = document.getElementById("admin-login-screen");
+      const mainContent = document.getElementById("admin-main-content");
+
+      if (loadingScreen) loadingScreen.hidden = view !== "loading";
+      if (loginScreen) loginScreen.hidden = view !== "login";
+      if (mainContent) mainContent.hidden = view !== "main";
     }
     // ── End auth ─────────────────────────────────────────────────
 
@@ -1117,11 +1121,13 @@
       document.body.classList.add("admin-mode");
       displayApp.hidden = true;
       adminApp.hidden = false;
+      setAdminAuthView("loading");
       initLoginFormListeners();
 
       const session = await checkAdminAuthSession();
       if (!session) {
-        return; // login screen is already visible by default
+        setAdminAuthView("login");
+        return;
       }
 
       const userRow = await lookupAdminUserRow(session.user.id);
@@ -1130,11 +1136,7 @@
         adminCurrentUser = buildAdminCurrentUser(session.user.id, userRow);
       }
 
-      const loginScreen = document.getElementById("admin-login-screen");
-      const mainContent = document.getElementById("admin-main-content");
-      if (loginScreen) loginScreen.hidden = true;
-      if (mainContent) mainContent.hidden = false;
-
+      setAdminAuthView("main");
       startAdminUI();
     }
 

--- a/js/admin-core.js
+++ b/js/admin-core.js
@@ -1198,12 +1198,18 @@
       loadAdminTodos();
       loadAdminMealPlan();
       initSettingsListeners();
+      if (typeof initAdminOnboarding === "function") {
+        initAdminOnboarding();
+      }
       ensureAdminHouseholdConfigLoaded()
         .then(() => {
           markAdminLoadSynced();
           loadAdminTodos();
           if (adminScreen === "settings") {
             loadAdminSettings();
+          }
+          if (typeof maybeAutoLaunchAdminOnboarding === "function") {
+            maybeAutoLaunchAdminOnboarding();
           }
         })
         .catch(() => showToast(friendlyLoadMessage()));

--- a/js/admin-onboarding.js
+++ b/js/admin-onboarding.js
@@ -228,11 +228,11 @@
         <ol class="admin-onboarding-instruction-list">
           <li class="admin-onboarding-instruction-item">
             <strong>Open Homeboard on your display device</strong>
-            <span>Navigate to <span class="admin-onboarding-inline-code">homeboard.chrisaug.com</span> on the tablet or screen you want to mount. It will show a 4-character pairing code.</span>
+            <span>Navigate to <span class="admin-onboarding-inline-code">homeboard.chrisaug.com</span> on the tablet or screen you want to mount. It will prompt you to enter a 4-character pairing code.</span>
           </li>
           <li class="admin-onboarding-instruction-item">
             <strong>Enter the code in Settings</strong>
-            <span>In your Admin, go to Settings &rarr; Display Setup and enter the code. Your display will pair instantly.</span>
+            <span>In your Admin, go to Settings &rarr; Display Setup to generate the 4-character code, then enter that code on your display device. Your display will pair instantly.</span>
           </li>
         </ol>
         <p class="admin-onboarding-note admin-onboarding-note--subtle">Don&apos;t have a display device set up yet? No problem — you can do this anytime from Settings.</p>

--- a/js/admin-onboarding.js
+++ b/js/admin-onboarding.js
@@ -1,0 +1,614 @@
+    const ADMIN_ONBOARDING_TOTAL_STEPS = 3;
+    const adminOnboardingFeatureCards = [
+      {
+        icon: "check-square",
+        title: "To-dos",
+        description: "Assign tasks to household members, set due dates, and keep track of what needs doing."
+      },
+      {
+        icon: "calendar",
+        title: "Calendar",
+        description: "See upcoming events at a glance. Connect Google Calendar to pull in events automatically."
+      },
+      {
+        icon: "timer",
+        title: "Countdowns",
+        description: "Track things you're looking forward to. Add your own events or turn a Google Calendar event into a countdown."
+      },
+      {
+        icon: "utensils",
+        title: "Meal Plan",
+        description: "Plan your meals for the week — cooking nights, takeout, Hello Fresh, and more."
+      },
+      {
+        icon: "trophy",
+        title: "Scorecards",
+        description: "Track friendly competitions between household members. Keep score, crown a winner."
+      }
+    ];
+
+    let adminOnboardingInitialized = false;
+    let adminOnboardingBusy = false;
+    let adminOnboardingState = {
+      isOpen: false,
+      mode: "signup",
+      step: 1,
+      canDismiss: false,
+      selectedTheme: "warm",
+      memberNames: [],
+      error: ""
+    };
+
+    function getAdminOnboardingRoot() {
+      return document.getElementById("admin-onboarding");
+    }
+
+    function getAdminOnboardingBody() {
+      return document.getElementById("admin-onboarding-body");
+    }
+
+    function getAdminOnboardingCloseButton() {
+      return document.getElementById("admin-onboarding-close");
+    }
+
+    function isAdminOnboardingComplete() {
+      return adminCurrentUser?.preferences?.onboarding_complete === true;
+    }
+
+    function shouldAutoLaunchAdminOnboarding() {
+      const params = new URLSearchParams(window.location.search);
+      return params.get("onboarding") === "true" && !isAdminOnboardingComplete();
+    }
+
+    function buildAdminOnboardingMemberNames() {
+      const displayName = String(adminCurrentUser?.displayName || "").trim();
+      return [displayName];
+    }
+
+    function renderAdminOnboardingStep1() {
+      const firstName = escapeHtml(adminOnboardingState.memberNames[0] || "");
+      const additionalRows = adminOnboardingState.memberNames.slice(1).map((name, index) => `
+        <div class="admin-onboarding-member-row" data-onboarding-member-row="${index + 1}">
+          <input
+            class="admin-input"
+            type="text"
+            maxlength="40"
+            value="${escapeHtml(name)}"
+            data-onboarding-member-input="${index + 1}"
+            placeholder="Member name"
+            autocomplete="off"
+          >
+          <button class="admin-settings-member-remove" type="button" data-onboarding-remove-member="${index + 1}" aria-label="Remove member"${adminOnboardingBusy ? " disabled" : ""}>
+            <i data-lucide="x"></i>
+          </button>
+        </div>
+      `).join("");
+
+      return `
+        <div class="admin-onboarding-copy">
+          <h1 class="admin-onboarding-title" id="admin-onboarding-title">Who&apos;s in your household?</h1>
+          <p class="admin-onboarding-note">Add everyone who&apos;ll appear in Homeboard — family members, partners, kids. You can always add more later.</p>
+        </div>
+        ${adminOnboardingState.error ? `<p class="admin-onboarding-error">${escapeHtml(adminOnboardingState.error)}</p>` : ""}
+        <form id="admin-onboarding-step1-form" novalidate>
+          <div class="admin-onboarding-members">
+            <div class="admin-onboarding-member-row admin-onboarding-member-row--locked">
+              <input class="admin-input" type="text" maxlength="40" value="${firstName}" readonly aria-readonly="true">
+              <span class="admin-onboarding-member-lock">You</span>
+            </div>
+            ${additionalRows}
+          </div>
+          <button class="admin-onboarding-link-button" type="button" id="admin-onboarding-add-member"${adminOnboardingBusy ? " disabled" : ""}>Add another member</button>
+          <div class="admin-onboarding-actions">
+            <span></span>
+            <div class="admin-onboarding-actions-group">
+              <button class="admin-button admin-button--primary" type="submit"${adminOnboardingBusy ? " disabled" : ""}>Continue</button>
+            </div>
+          </div>
+        </form>
+      `;
+    }
+
+    function renderAdminOnboardingStep2() {
+      const options = [
+        { value: "warm", label: "Warm" },
+        { value: "dark", label: "Dark" },
+        { value: "slate", label: "Slate" }
+      ];
+
+      return `
+        <div class="admin-onboarding-copy">
+          <h1 class="admin-onboarding-title" id="admin-onboarding-title">Choose your display style</h1>
+          <p class="admin-onboarding-note">This controls how Homeboard looks on your wall display. You can change it anytime in Settings.</p>
+        </div>
+        ${adminOnboardingState.error ? `<p class="admin-onboarding-error">${escapeHtml(adminOnboardingState.error)}</p>` : ""}
+        <div class="admin-onboarding-theme-grid" role="radiogroup" aria-label="Display style">
+          ${options.map((option) => `
+            <button
+              class="admin-onboarding-theme-card${adminOnboardingState.selectedTheme === option.value ? " is-selected" : ""}"
+              type="button"
+              data-onboarding-theme="${option.value}"
+              data-theme="${option.value}"
+              role="radio"
+              aria-checked="${adminOnboardingState.selectedTheme === option.value ? "true" : "false"}"
+            >
+              <span class="admin-onboarding-theme-preview" aria-hidden="true"></span>
+              <span class="admin-onboarding-theme-name">${option.label}</span>
+            </button>
+          `).join("")}
+        </div>
+        <div class="admin-onboarding-actions">
+          <button class="admin-button admin-button--secondary" type="button" id="admin-onboarding-back"${adminOnboardingBusy ? " disabled" : ""}>Back</button>
+          <div class="admin-onboarding-actions-group">
+            <button class="admin-button admin-button--primary" type="button" id="admin-onboarding-continue-theme"${adminOnboardingBusy ? " disabled" : ""}>Continue</button>
+          </div>
+        </div>
+      `;
+    }
+
+    function renderAdminOnboardingStep3() {
+      return `
+        <div class="admin-onboarding-copy">
+          <h1 class="admin-onboarding-title" id="admin-onboarding-title">Here&apos;s what Homeboard does</h1>
+          <p class="admin-onboarding-note">A quick look at what you can manage from your Admin.</p>
+        </div>
+        ${adminOnboardingState.error ? `<p class="admin-onboarding-error">${escapeHtml(adminOnboardingState.error)}</p>` : ""}
+        <div class="admin-onboarding-feature-grid">
+          ${adminOnboardingFeatureCards.map((feature) => `
+            <article class="admin-onboarding-feature-card">
+              <span class="admin-onboarding-feature-icon" aria-hidden="true"><i data-lucide="${escapeHtml(feature.icon)}"></i></span>
+              <div>
+                <h2 class="admin-onboarding-feature-title">${escapeHtml(feature.title)}</h2>
+                <p class="admin-onboarding-feature-copy">${escapeHtml(feature.description)}</p>
+              </div>
+            </article>
+          `).join("")}
+        </div>
+        <div class="admin-onboarding-actions">
+          <button class="admin-button admin-button--secondary" type="button" id="admin-onboarding-back"${adminOnboardingBusy ? " disabled" : ""}>Back</button>
+          <div class="admin-onboarding-actions-group">
+            <button class="admin-button admin-button--primary" type="button" id="admin-onboarding-finish"${adminOnboardingBusy ? " disabled" : ""}>Get started</button>
+          </div>
+        </div>
+      `;
+    }
+
+    function renderAdminOnboarding() {
+      const root = getAdminOnboardingRoot();
+      const body = getAdminOnboardingBody();
+      const stepLabel = document.getElementById("admin-onboarding-step-label");
+      const closeButton = getAdminOnboardingCloseButton();
+      if (!root || !body || !stepLabel || !closeButton) {
+        return;
+      }
+
+      stepLabel.textContent = `Step ${adminOnboardingState.step} of ${ADMIN_ONBOARDING_TOTAL_STEPS}`;
+      closeButton.hidden = !adminOnboardingState.canDismiss;
+
+      if (adminOnboardingState.step === 1) {
+        body.innerHTML = renderAdminOnboardingStep1();
+      } else if (adminOnboardingState.step === 2) {
+        body.innerHTML = renderAdminOnboardingStep2();
+      } else {
+        body.innerHTML = renderAdminOnboardingStep3();
+      }
+
+      refreshIcons();
+    }
+
+    function openAdminOnboarding(mode = "tour") {
+      const root = getAdminOnboardingRoot();
+      if (!root) {
+        return;
+      }
+
+      adminOnboardingState = {
+        isOpen: true,
+        mode,
+        step: 1,
+        canDismiss: mode === "tour",
+        selectedTheme: "warm",
+        memberNames: buildAdminOnboardingMemberNames(),
+        error: ""
+      };
+      adminOnboardingBusy = false;
+      root.hidden = false;
+      document.body.style.overflow = "hidden";
+      renderAdminOnboarding();
+    }
+
+    function closeAdminOnboarding() {
+      const root = getAdminOnboardingRoot();
+      if (!root) {
+        return;
+      }
+
+      adminOnboardingState.isOpen = false;
+      adminOnboardingState.error = "";
+      adminOnboardingBusy = false;
+      root.hidden = true;
+      document.body.style.overflow = "";
+    }
+
+    function removeOnboardingParamFromUrl() {
+      const nextUrl = new URL(window.location.href);
+      nextUrl.searchParams.delete("onboarding");
+      const nextPath = `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`;
+      window.history.replaceState(window.history.state, "", nextPath);
+    }
+
+    function buildNextDisplaySettingsMembers(namesToEnsure) {
+      const existingMembers = Array.isArray(adminHouseholdSettings?.display_settings?.members)
+        ? adminHouseholdSettings.display_settings.members
+            .map((member) => ({
+              name: String(member?.name || "").trim(),
+              color: String(member?.color || "").trim()
+            }))
+            .filter((member) => member.name)
+        : [];
+      const nextMembers = [...existingMembers];
+      const existingNames = new Set(nextMembers.map((member) => member.name.toLowerCase()));
+
+      namesToEnsure.forEach((name) => {
+        const safeName = String(name || "").trim();
+        if (!safeName || existingNames.has(safeName.toLowerCase())) {
+          return;
+        }
+        nextMembers.push({
+          name: safeName,
+          color: PERSON_COLOR_PALETTE[nextMembers.length % PERSON_COLOR_PALETTE.length]
+        });
+        existingNames.add(safeName.toLowerCase());
+      });
+
+      return {
+        ...adminHouseholdSettings.display_settings,
+        members: nextMembers
+      };
+    }
+
+    function collectAdminOnboardingNames() {
+      const names = adminOnboardingState.memberNames.map((name) => String(name || "").trim());
+      const duplicateNames = new Set();
+      const seen = new Set();
+
+      names.forEach((name) => {
+        const normalized = name.toLowerCase();
+        if (!normalized) {
+          return;
+        }
+        if (seen.has(normalized)) {
+          duplicateNames.add(normalized);
+          return;
+        }
+        seen.add(normalized);
+      });
+
+      if (names.some((name) => !name)) {
+        adminOnboardingState.error = "Add a name for every household member before continuing.";
+        return null;
+      }
+
+      if (duplicateNames.size > 0) {
+        adminOnboardingState.error = "Each household member should only be listed once.";
+        return null;
+      }
+
+      adminOnboardingState.error = "";
+      adminOnboardingState.memberNames = names;
+      return names;
+    }
+
+    async function saveAdminOnboardingMembers() {
+      const client = getSupabaseClient();
+      const names = collectAdminOnboardingNames();
+      if (!client || !names || !adminCurrentUser?.id) {
+        if (!client) {
+          adminOnboardingState.error = friendlySaveMessage();
+          renderAdminOnboarding();
+        }
+        return;
+      }
+
+      adminOnboardingBusy = true;
+      renderAdminOnboarding();
+
+      try {
+        const { data: existingMembers, error: existingMembersError } = await client
+          .from("household_members")
+          .select("display_name")
+          .eq("household_id", getAdminHouseholdId());
+
+        if (existingMembersError) {
+          adminOnboardingState.error = friendlySaveMessage();
+          return;
+        }
+
+        const existingMemberNames = new Set(
+          (existingMembers || [])
+            .map((member) => String(member?.display_name || "").trim().toLowerCase())
+            .filter(Boolean)
+        );
+
+        const additionalNames = names.slice(1).filter((name) => !existingMemberNames.has(name.toLowerCase()));
+        if (additionalNames.length > 0) {
+          const { error: insertError } = await client
+            .from("household_members")
+            .insert(additionalNames.map((name) => ({
+              household_id: getAdminHouseholdId(),
+              display_name: name
+            })));
+
+          if (insertError) {
+            adminOnboardingState.error = friendlySaveMessage();
+            return;
+          }
+        }
+
+        const nextDisplaySettings = buildNextDisplaySettingsMembers(names);
+        const { error: householdError } = await client
+          .from("households")
+          .update({ display_settings: nextDisplaySettings })
+          .eq("id", getAdminHouseholdId());
+
+        if (householdError) {
+          adminOnboardingState.error = friendlySaveMessage();
+          return;
+        }
+
+        adminHouseholdSettings.display_settings = nextDisplaySettings;
+        adminOnboardingState.step = 2;
+        adminOnboardingState.error = "";
+        if (typeof loadAdminSettings === "function" && adminScreen === "settings") {
+          loadAdminSettings();
+        }
+        if (typeof loadAdminTodos === "function") {
+          loadAdminTodos();
+        }
+      } finally {
+        adminOnboardingBusy = false;
+        renderAdminOnboarding();
+      }
+    }
+
+    async function saveAdminOnboardingTheme() {
+      const client = getSupabaseClient();
+      if (!client || !adminCurrentUser?.id) {
+        adminOnboardingState.error = friendlySaveMessage();
+        renderAdminOnboarding();
+        return;
+      }
+
+      adminOnboardingBusy = true;
+      renderAdminOnboarding();
+
+      try {
+        const selectedTheme = normalizeAdminTheme(adminOnboardingState.selectedTheme);
+        const { error: householdError } = await client
+          .from("households")
+          .update({ color_scheme: selectedTheme })
+          .eq("id", getAdminHouseholdId());
+
+        if (householdError) {
+          adminOnboardingState.error = friendlySaveMessage();
+          return;
+        }
+
+        const nextPreferences = {
+          ...(adminCurrentUser.preferences || {}),
+          admin_theme: selectedTheme
+        };
+        const { data, error: userError } = await client
+          .from("users")
+          .update({ preferences: nextPreferences })
+          .eq("id", adminCurrentUser.id)
+          .select("preferences")
+          .single();
+
+        if (userError || !data) {
+          adminOnboardingState.error = friendlySaveMessage();
+          return;
+        }
+
+        adminCurrentUser = {
+          ...adminCurrentUser,
+          preferences: {
+            ...(data.preferences && typeof data.preferences === "object" ? data.preferences : {}),
+            admin_theme: normalizeAdminTheme(data.preferences?.admin_theme)
+          }
+        };
+        adminHouseholdSettings.color_scheme = selectedTheme;
+        applyAdminTheme(selectedTheme);
+        if (typeof loadAdminAccountSettings === "function") {
+          loadAdminAccountSettings();
+        }
+        if (typeof loadAdminSettings === "function" && adminScreen === "settings") {
+          loadAdminSettings();
+        }
+        adminOnboardingState.step = 3;
+        adminOnboardingState.error = "";
+      } finally {
+        adminOnboardingBusy = false;
+        renderAdminOnboarding();
+      }
+    }
+
+    async function completeAdminOnboarding() {
+      const client = getSupabaseClient();
+      if (!client || !adminCurrentUser?.id) {
+        adminOnboardingState.error = friendlySaveMessage();
+        renderAdminOnboarding();
+        return;
+      }
+
+      adminOnboardingBusy = true;
+      renderAdminOnboarding();
+
+      try {
+        const nextPreferences = {
+          ...(adminCurrentUser.preferences || {}),
+          onboarding_complete: true
+        };
+        const { data, error } = await client
+          .from("users")
+          .update({ preferences: nextPreferences })
+          .eq("id", adminCurrentUser.id)
+          .select("preferences")
+          .single();
+
+        if (error || !data) {
+          adminOnboardingState.error = friendlySaveMessage();
+          return;
+        }
+
+        adminCurrentUser = {
+          ...adminCurrentUser,
+          preferences: {
+            ...(data.preferences && typeof data.preferences === "object" ? data.preferences : {}),
+            admin_theme: normalizeAdminTheme(data.preferences?.admin_theme)
+          }
+        };
+        removeOnboardingParamFromUrl();
+        if (typeof loadAdminAccountSettings === "function") {
+          loadAdminAccountSettings();
+        }
+        closeAdminOnboarding();
+      } finally {
+        adminOnboardingBusy = false;
+        if (adminOnboardingState.isOpen) {
+          renderAdminOnboarding();
+        }
+      }
+    }
+
+    function handleAdminOnboardingBodyClick(event) {
+      if (!adminOnboardingState.isOpen) {
+        return;
+      }
+      if (adminOnboardingBusy) {
+        return;
+      }
+
+      const removeButton = event.target.closest("[data-onboarding-remove-member]");
+      if (removeButton) {
+        const index = Number(removeButton.getAttribute("data-onboarding-remove-member"));
+        if (Number.isInteger(index) && index > 0) {
+          adminOnboardingState.memberNames.splice(index, 1);
+          adminOnboardingState.error = "";
+          renderAdminOnboarding();
+        }
+        return;
+      }
+
+      if (event.target.closest("#admin-onboarding-add-member")) {
+        adminOnboardingState.memberNames.push("");
+        adminOnboardingState.error = "";
+        renderAdminOnboarding();
+        const inputs = Array.from(document.querySelectorAll("[data-onboarding-member-input]"));
+        const lastInput = inputs[inputs.length - 1];
+        if (lastInput) {
+          lastInput.focus();
+        }
+        return;
+      }
+
+      const themeButton = event.target.closest("[data-onboarding-theme]");
+      if (themeButton) {
+        adminOnboardingState.selectedTheme = normalizeAdminTheme(themeButton.getAttribute("data-onboarding-theme"));
+        adminOnboardingState.error = "";
+        renderAdminOnboarding();
+        return;
+      }
+
+      if (event.target.closest("#admin-onboarding-back")) {
+        adminOnboardingState.step = Math.max(1, adminOnboardingState.step - 1);
+        adminOnboardingState.error = "";
+        renderAdminOnboarding();
+        return;
+      }
+
+      if (event.target.closest("#admin-onboarding-continue-theme")) {
+        saveAdminOnboardingTheme();
+        return;
+      }
+
+      if (event.target.closest("#admin-onboarding-finish")) {
+        completeAdminOnboarding();
+      }
+    }
+
+    function handleAdminOnboardingBodyInput(event) {
+      const input = event.target.closest("[data-onboarding-member-input]");
+      if (!input) {
+        return;
+      }
+      const index = Number(input.getAttribute("data-onboarding-member-input"));
+      if (!Number.isInteger(index) || index < 1) {
+        return;
+      }
+      adminOnboardingState.memberNames[index] = String(input.value || "").slice(0, 40);
+      adminOnboardingState.error = "";
+    }
+
+    function handleAdminOnboardingBodySubmit(event) {
+      const form = event.target.closest("#admin-onboarding-step1-form");
+      if (!form) {
+        return;
+      }
+      event.preventDefault();
+      saveAdminOnboardingMembers();
+    }
+
+    function handleAdminOnboardingClose() {
+      if (!adminOnboardingState.canDismiss || adminOnboardingBusy) {
+        return;
+      }
+      closeAdminOnboarding();
+    }
+
+    function handleAdminOnboardingKeydown(event) {
+      if (event.key !== "Escape" || !adminOnboardingState.isOpen || !adminOnboardingState.canDismiss) {
+        return;
+      }
+      event.preventDefault();
+      handleAdminOnboardingClose();
+    }
+
+    function initAdminOnboarding() {
+      if (adminOnboardingInitialized) {
+        return;
+      }
+      adminOnboardingInitialized = true;
+
+      const body = getAdminOnboardingBody();
+      const closeButton = getAdminOnboardingCloseButton();
+      const relaunchButton = document.getElementById("settings-onboarding-tour-btn");
+
+      if (body) {
+        body.addEventListener("click", handleAdminOnboardingBodyClick);
+        body.addEventListener("input", handleAdminOnboardingBodyInput);
+        body.addEventListener("submit", handleAdminOnboardingBodySubmit);
+      }
+      if (closeButton) {
+        closeButton.addEventListener("click", handleAdminOnboardingClose);
+      }
+      if (relaunchButton) {
+        relaunchButton.addEventListener("click", () => openAdminOnboarding("tour"));
+      }
+      document.addEventListener("keydown", handleAdminOnboardingKeydown);
+    }
+
+    async function maybeAutoLaunchAdminOnboarding() {
+      if (!shouldAutoLaunchAdminOnboarding() || adminOnboardingState.isOpen) {
+        return;
+      }
+
+      try {
+        await ensureAdminHouseholdConfigLoaded();
+      } catch {
+        showToast(friendlyLoadMessage());
+        return;
+      }
+
+      openAdminOnboarding("signup");
+    }

--- a/js/admin-onboarding.js
+++ b/js/admin-onboarding.js
@@ -29,6 +29,7 @@
 
     let adminOnboardingInitialized = false;
     let adminOnboardingBusy = false;
+    let adminOnboardingPreviousActiveElement = null;
     let adminOnboardingState = {
       isOpen: false,
       mode: "signup",
@@ -60,22 +61,37 @@
       return params.get("onboarding") === "true" && !isAdminOnboardingComplete();
     }
 
-    function buildAdminOnboardingDefaultMemberRows() {
+    function buildAdminOnboardingDefaultMemberRows(existingMemberNames = []) {
+      const displayName = String(adminCurrentUser?.displayName || "").trim();
+      const normalizedExistingNames = Array.isArray(existingMemberNames)
+        ? existingMemberNames.map((name) => String(name || "").trim().toLowerCase()).filter(Boolean)
+        : [];
       return [
         {
-          name: String(adminCurrentUser?.displayName || "").trim(),
-          existing: true,
+          name: displayName,
+          existing: normalizedExistingNames.includes(displayName.toLowerCase()),
           locked: true
         }
       ];
     }
 
     async function loadAdminOnboardingMemberRows(mode) {
+      const client = getSupabaseClient();
       if (mode !== "tour") {
-        return buildAdminOnboardingDefaultMemberRows();
+        if (!client) {
+          return buildAdminOnboardingDefaultMemberRows();
+        }
+        const { data, error } = await client
+          .from("household_members")
+          .select("display_name")
+          .eq("household_id", getAdminHouseholdId())
+          .eq("is_active", true);
+        const existingMemberNames = error || !Array.isArray(data)
+          ? []
+          : data.map((member) => String(member?.display_name || "").trim()).filter(Boolean);
+        return buildAdminOnboardingDefaultMemberRows(existingMemberNames);
       }
 
-      const client = getSupabaseClient();
       if (!client) {
         return buildAdminOnboardingDefaultMemberRows();
       }
@@ -104,10 +120,9 @@
 
       const hasLockedRow = rows.some((row) => row.locked);
       if (!hasLockedRow && signedInName) {
+        const existingMemberNames = rows.map((row) => row.name);
         rows.unshift({
-          name: signedInName,
-          existing: true,
-          locked: true
+          ...buildAdminOnboardingDefaultMemberRows(existingMemberNames)[0]
         });
       }
 
@@ -276,13 +291,21 @@
         return;
       }
 
+      adminOnboardingPreviousActiveElement = document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
       const memberRows = await loadAdminOnboardingMemberRows(mode);
+      const initialTheme = normalizeAdminTheme(
+        adminCurrentUser?.preferences?.admin_theme
+          || adminHouseholdSettings?.color_scheme
+          || "warm"
+      );
       adminOnboardingState = {
         isOpen: true,
         mode,
         step: 1,
         canDismiss: mode === "tour",
-        selectedTheme: "warm",
+        selectedTheme: initialTheme,
         memberRows,
         error: ""
       };
@@ -290,6 +313,12 @@
       root.hidden = false;
       document.body.style.overflow = "hidden";
       renderAdminOnboarding();
+      const firstInteractiveElement = root.querySelector(
+        'button, a[href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (firstInteractiveElement instanceof HTMLElement) {
+        firstInteractiveElement.focus();
+      }
     }
 
     function closeAdminOnboarding() {
@@ -303,6 +332,10 @@
       adminOnboardingBusy = false;
       root.hidden = true;
       document.body.style.overflow = "";
+      if (adminOnboardingPreviousActiveElement instanceof HTMLElement) {
+        adminOnboardingPreviousActiveElement.focus();
+      }
+      adminOnboardingPreviousActiveElement = null;
     }
 
     function removeOnboardingParamFromUrl() {
@@ -364,11 +397,13 @@
 
       if (rows.some((row) => !row.name)) {
         adminOnboardingState.error = "Add a name for every household member before continuing.";
+        renderAdminOnboarding();
         return null;
       }
 
       if (duplicateNames.size > 0) {
         adminOnboardingState.error = "Each household member should only be listed once.";
+        renderAdminOnboarding();
         return null;
       }
 
@@ -383,8 +418,8 @@
       if (!client || !rows || !adminCurrentUser?.id) {
         if (!client) {
           adminOnboardingState.error = friendlySaveMessage();
-          renderAdminOnboarding();
         }
+        renderAdminOnboarding();
         return;
       }
 
@@ -470,40 +505,58 @@
 
       try {
         const selectedTheme = normalizeAdminTheme(adminOnboardingState.selectedTheme);
-        const { error: householdError } = await client
-          .from("households")
-          .update({ color_scheme: selectedTheme })
-          .eq("id", getAdminHouseholdId());
+        const currentAdminTheme = normalizeAdminTheme(adminCurrentUser?.preferences?.admin_theme);
+        const currentHouseholdTheme = normalizeAdminTheme(adminHouseholdSettings?.color_scheme);
+        const shouldUpdateHouseholdTheme = currentHouseholdTheme !== selectedTheme;
+        const shouldUpdateAdminTheme = currentAdminTheme !== selectedTheme;
 
-        if (householdError) {
-          adminOnboardingState.error = friendlySaveMessage();
-          return;
-        }
+        if (shouldUpdateHouseholdTheme) {
+          const { error: householdError } = await client
+            .from("households")
+            .update({ color_scheme: selectedTheme })
+            .eq("id", getAdminHouseholdId());
 
-        const nextPreferences = {
-          ...(adminCurrentUser.preferences || {}),
-          admin_theme: selectedTheme
-        };
-        const { data, error: userError } = await client
-          .from("users")
-          .update({ preferences: nextPreferences })
-          .eq("id", adminCurrentUser.id)
-          .select("preferences")
-          .single();
-
-        if (userError || !data) {
-          adminOnboardingState.error = friendlySaveMessage();
-          return;
-        }
-
-        adminCurrentUser = {
-          ...adminCurrentUser,
-          preferences: {
-            ...(data.preferences && typeof data.preferences === "object" ? data.preferences : {}),
-            admin_theme: normalizeAdminTheme(data.preferences?.admin_theme)
+          if (householdError) {
+            adminOnboardingState.error = friendlySaveMessage();
+            return;
           }
-        };
-        adminHouseholdSettings.color_scheme = selectedTheme;
+          adminHouseholdSettings.color_scheme = selectedTheme;
+        }
+
+        if (shouldUpdateAdminTheme) {
+          const nextPreferences = {
+            ...(adminCurrentUser.preferences || {}),
+            admin_theme: selectedTheme
+          };
+          const { data, error: userError } = await client
+            .from("users")
+            .update({ preferences: nextPreferences })
+            .eq("id", adminCurrentUser.id)
+            .select("preferences")
+            .single();
+
+          if (userError || !data) {
+            adminOnboardingState.error = friendlySaveMessage();
+            return;
+          }
+
+          adminCurrentUser = {
+            ...adminCurrentUser,
+            preferences: {
+              ...(data.preferences && typeof data.preferences === "object" ? data.preferences : {}),
+              admin_theme: normalizeAdminTheme(data.preferences?.admin_theme)
+            }
+          };
+        } else {
+          adminCurrentUser = {
+            ...adminCurrentUser,
+            preferences: {
+              ...(adminCurrentUser.preferences || {}),
+              admin_theme: selectedTheme
+            }
+          };
+        }
+
         applyAdminTheme(selectedTheme);
         if (typeof loadAdminAccountSettings === "function") {
           loadAdminAccountSettings();
@@ -646,6 +699,11 @@
       }
       adminOnboardingState.memberRows[index].name = String(input.value || "").slice(0, 40);
       adminOnboardingState.error = "";
+      const errorBanner = document.querySelector(".admin-onboarding-error");
+      if (errorBanner instanceof HTMLElement) {
+        errorBanner.textContent = "";
+        errorBanner.hidden = true;
+      }
     }
 
     function handleAdminOnboardingBodySubmit(event) {

--- a/js/admin-onboarding.js
+++ b/js/admin-onboarding.js
@@ -1,4 +1,4 @@
-    const ADMIN_ONBOARDING_TOTAL_STEPS = 3;
+    const ADMIN_ONBOARDING_TOTAL_STEPS = 4;
     const adminOnboardingFeatureCards = [
       {
         icon: "list-todo",
@@ -147,12 +147,9 @@
         ${adminOnboardingState.error ? `<p class="admin-onboarding-error">${escapeHtml(adminOnboardingState.error)}</p>` : ""}
         <form id="admin-onboarding-step1-form" novalidate>
           <div class="admin-onboarding-members">${rowsMarkup}</div>
-          <button class="admin-button admin-button--secondary admin-onboarding-add-button" type="button" id="admin-onboarding-add-member"${adminOnboardingBusy ? " disabled" : ""}>Add another member</button>
-          <div class="admin-onboarding-actions">
-            <span></span>
-            <div class="admin-onboarding-actions-group">
-              <button class="admin-button admin-button--primary" type="submit"${adminOnboardingBusy ? " disabled" : ""}>Continue</button>
-            </div>
+          <div class="admin-onboarding-actions admin-onboarding-actions--step1">
+            <button class="admin-button admin-button--secondary admin-onboarding-add-button" type="button" id="admin-onboarding-add-member"${adminOnboardingBusy ? " disabled" : ""}>Add another member</button>
+            <button class="admin-button admin-button--primary" type="submit"${adminOnboardingBusy ? " disabled" : ""}>Continue</button>
           </div>
         </form>
       `;
@@ -216,6 +213,32 @@
         <div class="admin-onboarding-actions">
           <button class="admin-button admin-button--secondary" type="button" id="admin-onboarding-back"${adminOnboardingBusy ? " disabled" : ""}>Back</button>
           <div class="admin-onboarding-actions-group">
+            <button class="admin-button admin-button--primary" type="button" id="admin-onboarding-continue-features"${adminOnboardingBusy ? " disabled" : ""}>Continue</button>
+          </div>
+        </div>
+      `;
+    }
+
+    function renderAdminOnboardingStep4() {
+      return `
+        <div class="admin-onboarding-copy">
+          <h1 class="admin-onboarding-title" id="admin-onboarding-title">Set up your wall display</h1>
+          <p class="admin-onboarding-note">Homeboard is designed to run on a tablet or screen mounted in your home.</p>
+        </div>
+        <ol class="admin-onboarding-instruction-list">
+          <li class="admin-onboarding-instruction-item">
+            <strong>Open Homeboard on your display device</strong>
+            <span>Navigate to <span class="admin-onboarding-inline-code">homeboard.chrisaug.com</span> on the tablet or screen you want to mount. It will show a 4-character pairing code.</span>
+          </li>
+          <li class="admin-onboarding-instruction-item">
+            <strong>Enter the code in Settings</strong>
+            <span>In your Admin, go to Settings &rarr; Display Setup and enter the code. Your display will pair instantly.</span>
+          </li>
+        </ol>
+        <p class="admin-onboarding-note admin-onboarding-note--subtle">Don&apos;t have a display device set up yet? No problem — you can do this anytime from Settings.</p>
+        <div class="admin-onboarding-actions">
+          <button class="admin-button admin-button--secondary" type="button" id="admin-onboarding-back"${adminOnboardingBusy ? " disabled" : ""}>Back</button>
+          <div class="admin-onboarding-actions-group">
             <button class="admin-button admin-button--primary" type="button" id="admin-onboarding-finish"${adminOnboardingBusy ? " disabled" : ""}>Get started</button>
           </div>
         </div>
@@ -238,8 +261,10 @@
         body.innerHTML = renderAdminOnboardingStep1();
       } else if (adminOnboardingState.step === 2) {
         body.innerHTML = renderAdminOnboardingStep2();
-      } else {
+      } else if (adminOnboardingState.step === 3) {
         body.innerHTML = renderAdminOnboardingStep3();
+      } else {
+        body.innerHTML = renderAdminOnboardingStep4();
       }
 
       refreshIcons();
@@ -595,6 +620,13 @@
 
       if (event.target.closest("#admin-onboarding-continue-theme")) {
         saveAdminOnboardingTheme();
+        return;
+      }
+
+      if (event.target.closest("#admin-onboarding-continue-features")) {
+        adminOnboardingState.step = 4;
+        adminOnboardingState.error = "";
+        renderAdminOnboarding();
         return;
       }
 

--- a/js/admin-onboarding.js
+++ b/js/admin-onboarding.js
@@ -1,7 +1,7 @@
     const ADMIN_ONBOARDING_TOTAL_STEPS = 3;
     const adminOnboardingFeatureCards = [
       {
-        icon: "check-square",
+        icon: "list-todo",
         title: "To-dos",
         description: "Assign tasks to household members, set due dates, and keep track of what needs doing."
       },
@@ -11,7 +11,7 @@
         description: "See upcoming events at a glance. Connect Google Calendar to pull in events automatically."
       },
       {
-        icon: "timer",
+        icon: "hourglass",
         title: "Countdowns",
         description: "Track things you're looking forward to. Add your own events or turn a Google Calendar event into a countdown."
       },
@@ -35,7 +35,7 @@
       step: 1,
       canDismiss: false,
       selectedTheme: "warm",
-      memberNames: [],
+      memberRows: [],
       error: ""
     };
 
@@ -60,27 +60,82 @@
       return params.get("onboarding") === "true" && !isAdminOnboardingComplete();
     }
 
-    function buildAdminOnboardingMemberNames() {
-      const displayName = String(adminCurrentUser?.displayName || "").trim();
-      return [displayName];
+    function buildAdminOnboardingDefaultMemberRows() {
+      return [
+        {
+          name: String(adminCurrentUser?.displayName || "").trim(),
+          existing: true,
+          locked: true
+        }
+      ];
+    }
+
+    async function loadAdminOnboardingMemberRows(mode) {
+      if (mode !== "tour") {
+        return buildAdminOnboardingDefaultMemberRows();
+      }
+
+      const client = getSupabaseClient();
+      if (!client) {
+        return buildAdminOnboardingDefaultMemberRows();
+      }
+
+      const signedInName = String(adminCurrentUser?.displayName || "").trim();
+      const signedInNameKey = signedInName.toLowerCase();
+      const { data, error } = await client
+        .from("household_members")
+        .select("id, display_name")
+        .eq("household_id", getAdminHouseholdId())
+        .eq("is_active", true)
+        .order("display_name", { ascending: true });
+
+      if (error || !Array.isArray(data) || data.length === 0) {
+        return buildAdminOnboardingDefaultMemberRows();
+      }
+
+      const rows = data
+        .map((member) => ({
+          id: String(member?.id || "").trim(),
+          name: String(member?.display_name || "").trim(),
+          existing: true,
+          locked: String(member?.display_name || "").trim().toLowerCase() === signedInNameKey
+        }))
+        .filter((member) => member.name);
+
+      const hasLockedRow = rows.some((row) => row.locked);
+      if (!hasLockedRow && signedInName) {
+        rows.unshift({
+          name: signedInName,
+          existing: true,
+          locked: true
+        });
+      }
+
+      rows.sort((left, right) => Number(Boolean(right.locked)) - Number(Boolean(left.locked)));
+      return rows.length > 0 ? rows : buildAdminOnboardingDefaultMemberRows();
     }
 
     function renderAdminOnboardingStep1() {
-      const firstName = escapeHtml(adminOnboardingState.memberNames[0] || "");
-      const additionalRows = adminOnboardingState.memberNames.slice(1).map((name, index) => `
-        <div class="admin-onboarding-member-row" data-onboarding-member-row="${index + 1}">
+      const memberRows = Array.isArray(adminOnboardingState.memberRows)
+        ? adminOnboardingState.memberRows
+        : [];
+      const rowsMarkup = memberRows.map((row, index) => `
+        <div class="admin-onboarding-member-row${row.locked ? " admin-onboarding-member-row--locked" : ""}" data-onboarding-member-row="${index}">
           <input
             class="admin-input"
             type="text"
             maxlength="40"
-            value="${escapeHtml(name)}"
-            data-onboarding-member-input="${index + 1}"
+            value="${escapeHtml(row.name)}"
+            data-onboarding-member-input="${index}"
             placeholder="Member name"
             autocomplete="off"
+            ${row.locked ? 'readonly aria-readonly="true"' : ""}
           >
-          <button class="admin-settings-member-remove" type="button" data-onboarding-remove-member="${index + 1}" aria-label="Remove member"${adminOnboardingBusy ? " disabled" : ""}>
-            <i data-lucide="x"></i>
-          </button>
+          ${row.locked
+            ? '<span class="admin-onboarding-member-lock">You</span>'
+            : `<button class="admin-settings-member-remove" type="button" data-onboarding-remove-member="${index}" aria-label="Remove member"${adminOnboardingBusy ? " disabled" : ""}>
+                <i data-lucide="x"></i>
+              </button>`}
         </div>
       `).join("");
 
@@ -91,14 +146,8 @@
         </div>
         ${adminOnboardingState.error ? `<p class="admin-onboarding-error">${escapeHtml(adminOnboardingState.error)}</p>` : ""}
         <form id="admin-onboarding-step1-form" novalidate>
-          <div class="admin-onboarding-members">
-            <div class="admin-onboarding-member-row admin-onboarding-member-row--locked">
-              <input class="admin-input" type="text" maxlength="40" value="${firstName}" readonly aria-readonly="true">
-              <span class="admin-onboarding-member-lock">You</span>
-            </div>
-            ${additionalRows}
-          </div>
-          <button class="admin-onboarding-link-button" type="button" id="admin-onboarding-add-member"${adminOnboardingBusy ? " disabled" : ""}>Add another member</button>
+          <div class="admin-onboarding-members">${rowsMarkup}</div>
+          <button class="admin-button admin-button--secondary admin-onboarding-add-button" type="button" id="admin-onboarding-add-member"${adminOnboardingBusy ? " disabled" : ""}>Add another member</button>
           <div class="admin-onboarding-actions">
             <span></span>
             <div class="admin-onboarding-actions-group">
@@ -119,7 +168,7 @@
       return `
         <div class="admin-onboarding-copy">
           <h1 class="admin-onboarding-title" id="admin-onboarding-title">Choose your display style</h1>
-          <p class="admin-onboarding-note">This controls how Homeboard looks on your wall display. You can change it anytime in Settings.</p>
+          <p class="admin-onboarding-note">Pick the look and feel for your Admin and wall display. You can change it anytime in Settings.</p>
         </div>
         ${adminOnboardingState.error ? `<p class="admin-onboarding-error">${escapeHtml(adminOnboardingState.error)}</p>` : ""}
         <div class="admin-onboarding-theme-grid" role="radiogroup" aria-label="Display style">
@@ -196,19 +245,20 @@
       refreshIcons();
     }
 
-    function openAdminOnboarding(mode = "tour") {
+    async function openAdminOnboarding(mode = "tour") {
       const root = getAdminOnboardingRoot();
       if (!root) {
         return;
       }
 
+      const memberRows = await loadAdminOnboardingMemberRows(mode);
       adminOnboardingState = {
         isOpen: true,
         mode,
         step: 1,
         canDismiss: mode === "tour",
         selectedTheme: "warm",
-        memberNames: buildAdminOnboardingMemberNames(),
+        memberRows,
         error: ""
       };
       adminOnboardingBusy = false;
@@ -267,13 +317,16 @@
       };
     }
 
-    function collectAdminOnboardingNames() {
-      const names = adminOnboardingState.memberNames.map((name) => String(name || "").trim());
+    function collectAdminOnboardingRows() {
+      const rows = (adminOnboardingState.memberRows || []).map((row) => ({
+        ...row,
+        name: String(row?.name || "").trim()
+      }));
       const duplicateNames = new Set();
       const seen = new Set();
 
-      names.forEach((name) => {
-        const normalized = name.toLowerCase();
+      rows.forEach((row) => {
+        const normalized = row.name.toLowerCase();
         if (!normalized) {
           return;
         }
@@ -284,7 +337,7 @@
         seen.add(normalized);
       });
 
-      if (names.some((name) => !name)) {
+      if (rows.some((row) => !row.name)) {
         adminOnboardingState.error = "Add a name for every household member before continuing.";
         return null;
       }
@@ -295,14 +348,14 @@
       }
 
       adminOnboardingState.error = "";
-      adminOnboardingState.memberNames = names;
-      return names;
+      adminOnboardingState.memberRows = rows;
+      return rows;
     }
 
     async function saveAdminOnboardingMembers() {
       const client = getSupabaseClient();
-      const names = collectAdminOnboardingNames();
-      if (!client || !names || !adminCurrentUser?.id) {
+      const rows = collectAdminOnboardingRows();
+      if (!client || !rows || !adminCurrentUser?.id) {
         if (!client) {
           adminOnboardingState.error = friendlySaveMessage();
           renderAdminOnboarding();
@@ -330,7 +383,11 @@
             .filter(Boolean)
         );
 
-        const additionalNames = names.slice(1).filter((name) => !existingMemberNames.has(name.toLowerCase()));
+        const names = rows.map((row) => row.name);
+        const additionalNames = rows
+          .filter((row) => !row.existing)
+          .map((row) => row.name)
+          .filter((name) => !existingMemberNames.has(name.toLowerCase()));
         if (additionalNames.length > 0) {
           const { error: insertError } = await client
             .from("household_members")
@@ -356,6 +413,10 @@
           return;
         }
 
+        adminOnboardingState.memberRows = rows.map((row) => ({
+          ...row,
+          existing: true
+        }));
         adminHouseholdSettings.display_settings = nextDisplaySettings;
         adminOnboardingState.step = 2;
         adminOnboardingState.error = "";
@@ -492,8 +553,9 @@
       const removeButton = event.target.closest("[data-onboarding-remove-member]");
       if (removeButton) {
         const index = Number(removeButton.getAttribute("data-onboarding-remove-member"));
-        if (Number.isInteger(index) && index > 0) {
-          adminOnboardingState.memberNames.splice(index, 1);
+        const row = adminOnboardingState.memberRows[index];
+        if (Number.isInteger(index) && index >= 0 && row && !row.locked) {
+          adminOnboardingState.memberRows.splice(index, 1);
           adminOnboardingState.error = "";
           renderAdminOnboarding();
         }
@@ -501,7 +563,11 @@
       }
 
       if (event.target.closest("#admin-onboarding-add-member")) {
-        adminOnboardingState.memberNames.push("");
+        adminOnboardingState.memberRows.push({
+          name: "",
+          existing: false,
+          locked: false
+        });
         adminOnboardingState.error = "";
         renderAdminOnboarding();
         const inputs = Array.from(document.querySelectorAll("[data-onboarding-member-input]"));
@@ -543,10 +609,10 @@
         return;
       }
       const index = Number(input.getAttribute("data-onboarding-member-input"));
-      if (!Number.isInteger(index) || index < 1) {
+      if (!Number.isInteger(index) || index < 0 || !adminOnboardingState.memberRows[index]) {
         return;
       }
-      adminOnboardingState.memberNames[index] = String(input.value || "").slice(0, 40);
+      adminOnboardingState.memberRows[index].name = String(input.value || "").slice(0, 40);
       adminOnboardingState.error = "";
     }
 
@@ -593,7 +659,9 @@
         closeButton.addEventListener("click", handleAdminOnboardingClose);
       }
       if (relaunchButton) {
-        relaunchButton.addEventListener("click", () => openAdminOnboarding("tour"));
+        relaunchButton.addEventListener("click", () => {
+          openAdminOnboarding("tour");
+        });
       }
       document.addEventListener("keydown", handleAdminOnboardingKeydown);
     }

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.18";
+    const VERSION = "2.0.19";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.17";
+    const VERSION = "2.0.18";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.19";
+    const VERSION = "2.0.20";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.17";
+const CACHE_NAME = "homeboard-v2.0.18";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.19";
+const CACHE_NAME = "homeboard-v2.0.20";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.18";
+const CACHE_NAME = "homeboard-v2.0.19";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary
- add a 3-step admin onboarding overlay for new households landing on `/admin?onboarding=true`
- save onboarding members, theme choices, and `users.preferences.onboarding_complete` using the existing admin Supabase patterns
- add a Settings entry to relaunch the intro tour and document the onboarding flow in the README

## Why
New households created from signup need a guided first-run setup before they start using Homeboard. This keeps the existing admin UI intact while handling the required onboarding writes in a focused flow.

## Validation
- `node --check js/admin-onboarding.js`
- `node --check js/admin-core.js`
- `git diff --check`

AI-assisted: Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 3-step admin onboarding flow for newly signed-up admins to add household members and select a display theme.
  * Added a "Relaunch intro tour" option in Admin Settings to restart the onboarding guide.
  * Added an admin authentication loading screen displayed before login initializes.

* **Documentation**
  * Updated README with admin onboarding behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->