### PR TITLE
Migrate member management to household_members

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,10 @@ Core tables used by Homeboard:
 
 | Table | Purpose |
 |---|---|
-| `households` | household-level settings such as assistant name, color scheme, Google Calendar ID, and `display_settings` |
-| `household_members` | canonical list of household people created during signup and onboarding |
+| `households` | household-level settings such as assistant name, color scheme, Google Calendar ID, and `display_settings` (member data here is legacy fallback only) |
+| `household_members` | canonical list of household people, including `display_name`, `color`, and active status |
 | `users` | maps authenticated Supabase users to a household and role, and stores personal admin settings such as `display_name` and `preferences.admin_theme` |
-| `todos` | household to-dos; never hard-deleted |
+| `todos` | household to-dos; never hard-deleted; assignees use `assignee_member_id` with legacy text fallback in `assignee` |
 | `meal_plan` | weekly meal entries |
 | `meal_plan_notes` | one note per household per week |
 | `countdowns` | countdown definitions and photo metadata |

--- a/css/admin.css
+++ b/css/admin.css
@@ -2348,6 +2348,10 @@
       min-height: 20px;
     }
 
+    #admin-screen-settings {
+      padding-bottom: calc(56px + env(safe-area-inset-bottom));
+    }
+
     .admin-settings-footer-sync .last-synced-label {
       font-size: 0.72rem;
       opacity: 0.66;

--- a/js/admin-core.js
+++ b/js/admin-core.js
@@ -234,6 +234,7 @@
       assistant_name: "",
       color_scheme: "warm",
       google_cal_id: "",
+      household_members: [],
       display_settings: {
         members: []
       }
@@ -368,16 +369,39 @@
       return "Something went wrong deleting this item. Please try again.";
     }
 
-    function buildAdminAssigneePill(name) {
-      const memberColor = getConfiguredMemberColor(adminHouseholdSettings?.display_settings?.members, name);
+    function getAdminHouseholdMembers() {
+      return Array.isArray(adminHouseholdSettings?.household_members)
+        ? adminHouseholdSettings.household_members
+        : [];
+    }
+
+    function getNextHouseholdMemberColor(members) {
+      const normalizedMembers = normalizeHouseholdMembers(members);
+      const usedColors = new Set(
+        normalizedMembers
+          .map((member) => String(member?.color || "").trim().toLowerCase())
+          .filter(Boolean)
+      );
+      const nextUnused = PERSON_COLOR_PALETTE.find((color) => !usedColors.has(color.toLowerCase()));
+      if (nextUnused) {
+        return nextUnused;
+      }
+
+      return PERSON_COLOR_PALETTE[normalizedMembers.length % PERSON_COLOR_PALETTE.length];
+    }
+
+    function buildAdminAssigneePill(name, memberId = "") {
+      const assignee = resolveTodoAssignee(getAdminHouseholdMembers(), memberId, name);
+      const memberColor = String(assignee?.color || "").trim();
+      const label = assignee?.name || String(name || "").trim() || "Unassigned";
 
       if (!memberColor) {
-        return `<span class="admin-pill">${escapeHtml(name)}</span>`;
+        return `<span class="admin-pill">${escapeHtml(label)}</span>`;
       }
 
       return `
         <span class="admin-pill admin-pill--member" style="background:${escapeHtml(hexToRgba(memberColor, 0.16))};color:${escapeHtml(memberColor)}">
-          ${escapeHtml(name)}
+          ${escapeHtml(label)}
         </span>
       `;
     }

--- a/js/admin-core.js
+++ b/js/admin-core.js
@@ -35,7 +35,7 @@
       try {
         const { data, error } = await client
           .from("users")
-          .select("household_id, display_name, preferences")
+          .select("household_id, display_name, preferences, member_id")
           .eq("id", authUserId)
           .single();
         if (error || !data) return null;
@@ -55,6 +55,7 @@
         id: authUserId,
         displayName: userRow?.display_name || "",
         householdId: userRow?.household_id || DISPLAY_HOUSEHOLD_ID,
+        member_id: String(userRow?.member_id || "").trim(),
         preferences: {
           ...preferences,
           admin_theme: adminTheme

--- a/js/admin-onboarding.js
+++ b/js/admin-onboarding.js
@@ -345,36 +345,6 @@
       window.history.replaceState(window.history.state, "", nextPath);
     }
 
-    function buildNextDisplaySettingsMembers(namesToEnsure) {
-      const existingMembers = Array.isArray(adminHouseholdSettings?.display_settings?.members)
-        ? adminHouseholdSettings.display_settings.members
-            .map((member) => ({
-              name: String(member?.name || "").trim(),
-              color: String(member?.color || "").trim()
-            }))
-            .filter((member) => member.name)
-        : [];
-      const nextMembers = [...existingMembers];
-      const existingNames = new Set(nextMembers.map((member) => member.name.toLowerCase()));
-
-      namesToEnsure.forEach((name) => {
-        const safeName = String(name || "").trim();
-        if (!safeName || existingNames.has(safeName.toLowerCase())) {
-          return;
-        }
-        nextMembers.push({
-          name: safeName,
-          color: PERSON_COLOR_PALETTE[nextMembers.length % PERSON_COLOR_PALETTE.length]
-        });
-        existingNames.add(safeName.toLowerCase());
-      });
-
-      return {
-        ...adminHouseholdSettings.display_settings,
-        members: nextMembers
-      };
-    }
-
     function collectAdminOnboardingRows() {
       const rows = (adminOnboardingState.memberRows || []).map((row) => ({
         ...row,
@@ -429,7 +399,7 @@
       try {
         const { data: existingMembers, error: existingMembersError } = await client
           .from("household_members")
-          .select("display_name")
+          .select("id, display_name, color, is_active, created_at")
           .eq("household_id", getAdminHouseholdId());
 
         if (existingMembersError) {
@@ -437,24 +407,25 @@
           return;
         }
 
-        const existingMemberNames = new Set(
-          (existingMembers || [])
-            .map((member) => String(member?.display_name || "").trim().toLowerCase())
-            .filter(Boolean)
-        );
-
-        const names = rows.map((row) => row.name);
+        const normalizedExistingMembers = normalizeHouseholdMembers(existingMembers);
+        const existingMemberNames = new Set(normalizedExistingMembers.map((member) => member.display_name.toLowerCase()));
         const additionalNames = rows
           .filter((row) => !row.existing)
           .map((row) => row.name)
           .filter((name) => !existingMemberNames.has(name.toLowerCase()));
         if (additionalNames.length > 0) {
+          const membersForColorSelection = [...normalizedExistingMembers];
           const { error: insertError } = await client
             .from("household_members")
-            .insert(additionalNames.map((name) => ({
-              household_id: getAdminHouseholdId(),
-              display_name: name
-            })));
+            .insert(additionalNames.map((name) => {
+              const color = getNextHouseholdMemberColor(membersForColorSelection);
+              membersForColorSelection.push({ display_name: name, color });
+              return {
+                household_id: getAdminHouseholdId(),
+                display_name: name,
+                color
+              };
+            }));
 
           if (insertError) {
             adminOnboardingState.error = friendlySaveMessage();
@@ -462,22 +433,11 @@
           }
         }
 
-        const nextDisplaySettings = buildNextDisplaySettingsMembers(names);
-        const { error: householdError } = await client
-          .from("households")
-          .update({ display_settings: nextDisplaySettings })
-          .eq("id", getAdminHouseholdId());
-
-        if (householdError) {
-          adminOnboardingState.error = friendlySaveMessage();
-          return;
-        }
-
         adminOnboardingState.memberRows = rows.map((row) => ({
           ...row,
           existing: true
         }));
-        adminHouseholdSettings.display_settings = nextDisplaySettings;
+        adminHouseholdSettings.household_members = await fetchHouseholdMembers(getAdminHouseholdId()) || getAdminHouseholdMembers();
         adminOnboardingState.step = 2;
         adminOnboardingState.error = "";
         if (typeof loadAdminSettings === "function" && adminScreen === "settings") {

--- a/js/admin-onboarding.js
+++ b/js/admin-onboarding.js
@@ -408,11 +408,41 @@
         }
 
         const normalizedExistingMembers = normalizeHouseholdMembers(existingMembers);
-        const existingMemberNames = new Set(normalizedExistingMembers.map((member) => member.display_name.toLowerCase()));
+        const activeExistingMembers = normalizedExistingMembers.filter((member) => member.is_active);
+        const existingMemberNames = new Set(activeExistingMembers.map((member) => member.display_name.toLowerCase()));
+        const inactiveMembersByName = new Map(
+          normalizedExistingMembers
+            .filter((member) => !member.is_active)
+            .map((member) => [member.display_name.toLowerCase(), member])
+        );
+        const namesToReactivate = Array.from(new Set(
+          rows
+            .filter((row) => !row.existing)
+            .map((row) => row.name)
+            .filter((name) => inactiveMembersByName.has(name.toLowerCase()))
+        ));
+
+        if (namesToReactivate.length > 0) {
+          const memberIdsToReactivate = namesToReactivate
+            .map((name) => inactiveMembersByName.get(name.toLowerCase())?.id || "")
+            .filter(Boolean);
+          const { error: reactivateError } = await client
+            .from("household_members")
+            .update({ is_active: true })
+            .in("id", memberIdsToReactivate)
+            .eq("household_id", getAdminHouseholdId());
+
+          if (reactivateError) {
+            adminOnboardingState.error = friendlySaveMessage();
+            return;
+          }
+        }
+
         const additionalNames = rows
           .filter((row) => !row.existing)
           .map((row) => row.name)
-          .filter((name) => !existingMemberNames.has(name.toLowerCase()));
+          .filter((name) => !existingMemberNames.has(name.toLowerCase()))
+          .filter((name) => !inactiveMembersByName.has(name.toLowerCase()));
         if (additionalNames.length > 0) {
           const membersForColorSelection = [...normalizedExistingMembers];
           const { error: insertError } = await client
@@ -437,7 +467,16 @@
           ...row,
           existing: true
         }));
-        adminHouseholdSettings.household_members = await fetchHouseholdMembers(getAdminHouseholdId()) || getAdminHouseholdMembers();
+        const cachedMembersById = new Map(
+          getAdminHouseholdMembers()
+            .filter((member) => member?.has_linked_login === true)
+            .map((member) => [String(member.id || "").trim(), true])
+        );
+        const refreshedMembers = await fetchHouseholdMembers(getAdminHouseholdId());
+        adminHouseholdSettings.household_members = (refreshedMembers || getAdminHouseholdMembers()).map((member) => ({
+          ...member,
+          has_linked_login: member?.has_linked_login === true || cachedMembersById.has(String(member.id || "").trim())
+        }));
         adminOnboardingState.step = 2;
         adminOnboardingState.error = "";
         if (typeof loadAdminSettings === "function" && adminScreen === "settings") {

--- a/js/admin-scorecard.js
+++ b/js/admin-scorecard.js
@@ -401,14 +401,12 @@
     }
 
     function getDefaultScorecardPlayers() {
-      const members = Array.isArray(adminHouseholdSettings?.display_settings?.members)
-        ? adminHouseholdSettings.display_settings.members.filter((member) => member && member.name)
-        : [];
+      const members = getAdminHouseholdMembers();
       if (members.length) {
         return Array.from({ length: 2 }, (_, index) => {
           const member = members[index];
           return {
-            name: member?.name || "",
+            name: member?.display_name || "",
             color: member?.color || SCORECARD_PLAYER_COLOR_PALETTE[index % SCORECARD_PLAYER_COLOR_PALETTE.length]
           };
         });

--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -602,12 +602,22 @@
           showToast(friendlySaveMessage());
         } else {
           if (adminCurrentUser?.member_id) {
-            try {
-              await client
-                .from("household_members")
-                .update({ display_name: nextDisplayName })
-                .eq("id", adminCurrentUser.member_id);
-            } catch {}
+            if (!nextDisplayName) {
+              console.warn("Skipping household member display name sync because the saved account display name is blank.");
+            } else {
+              try {
+                const { error: memberSyncError } = await client
+                  .from("household_members")
+                  .update({ display_name: nextDisplayName })
+                  .eq("id", adminCurrentUser.member_id);
+
+                if (memberSyncError) {
+                  console.warn("Failed to sync account display name to household member.", memberSyncError);
+                }
+              } catch (memberSyncError) {
+                console.warn("Failed to sync account display name to household member.", memberSyncError);
+              }
+            }
           }
 
           adminCurrentUser = {

--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -7,30 +7,50 @@
         throw new Error("Supabase client unavailable");
       }
 
-      const { data, error } = await client
-        .from("households")
-        .select("assistant_name, color_scheme, google_cal_id, display_settings")
-        .eq("id", getAdminHouseholdId())
-        .single();
+      const householdId = getAdminHouseholdId();
+      const [
+        { data, error },
+        { data: memberRows, error: memberError },
+        { data: userRows, error: userError }
+      ] = await Promise.all([
+        client
+          .from("households")
+          .select("assistant_name, color_scheme, google_cal_id, display_settings")
+          .eq("id", householdId)
+          .single(),
+        client
+          .from("household_members")
+          .select("id, display_name, color, is_active, created_at")
+          .eq("household_id", householdId)
+          .eq("is_active", true)
+          .order("display_name", { ascending: true }),
+        client
+          .from("users")
+          .select("member_id")
+          .eq("household_id", householdId)
+      ]);
 
-      if (error || !data) {
+      if (error || !data || memberError || userError) {
         throw new Error("Failed to load household config");
       }
 
       const ds = normalizeDisplaySettings(data.display_settings);
-      ds.members = Array.isArray(data.display_settings?.members)
-        ? data.display_settings.members
-          .map((member) => ({
-            name: String(member?.name || "").trim(),
-            color: String(member?.color || "").trim()
-          }))
-          .filter((member) => member.name)
-        : [];
+      ds.members = Array.isArray(data.display_settings?.members) ? data.display_settings.members : [];
+      const linkedMemberIds = new Set(
+        Array.isArray(userRows)
+          ? userRows.map((row) => String(row?.member_id || "").trim()).filter(Boolean)
+          : []
+      );
+      const householdMembers = normalizeHouseholdMembers(memberRows).map((member) => ({
+        ...member,
+        has_linked_login: linkedMemberIds.has(member.id)
+      }));
 
       adminHouseholdSettings = {
         assistant_name: data.assistant_name || "",
         color_scheme: data.color_scheme || "warm",
         google_cal_id: data.google_cal_id || "",
+        household_members: householdMembers,
         display_settings: ds
       };
 
@@ -144,7 +164,7 @@
       list.innerHTML = members.map((m, i) => `
         ${pendingMemberRemovalIndex === i ? `
           <div class="admin-settings-member-row admin-settings-member-row--confirm" data-member-index="${i}">
-            <span class="admin-settings-member-confirm-text">Remove ${escapeHtml(m.name)}?</span>
+            <span class="admin-settings-member-confirm-text">Remove ${escapeHtml(m.display_name)}?</span>
             <div class="admin-settings-member-actions">
               <button type="button" class="admin-button admin-button--danger admin-button--small" data-member-confirm="${i}"${membersSavePending ? " disabled" : ""}>Confirm</button>
               <button type="button" class="admin-button admin-button--secondary admin-button--small" data-member-cancel="${i}"${membersSavePending ? " disabled" : ""}>Cancel</button>
@@ -153,10 +173,13 @@
         ` : `
           <div class="admin-settings-member-row" data-member-index="${i}">
             <span class="admin-settings-member-color" style="background:${escapeHtml(m.color || "#999")}"></span>
-            <span class="admin-settings-member-name">${escapeHtml(m.name)}</span>
-            <button type="button" class="admin-settings-member-remove" data-member-remove="${i}" aria-label="Remove ${escapeHtml(m.name)}"${membersSavePending ? " disabled" : ""}>
-              <i data-lucide="x"></i>
-            </button>
+            <span class="admin-settings-member-name">${escapeHtml(m.display_name)}</span>
+            <div class="admin-settings-member-actions">
+              <span class="admin-pill${m.has_linked_login ? " admin-pill--member" : ""}">${m.has_linked_login ? "Has login" : "No login"}</span>
+              <button type="button" class="admin-settings-member-remove" data-member-remove="${i}" aria-label="Remove ${escapeHtml(m.display_name)}"${membersSavePending ? " disabled" : ""}>
+                <i data-lucide="x"></i>
+              </button>
+            </div>
           </div>
         `}
       `).join("");
@@ -245,7 +268,7 @@
       const screenOrder = normalizeAdminScreenOrder(Array.isArray(ds.screen_order) ? ds.screen_order : configurableScreens);
       const timerIntervals = ds.timer_intervals || {};
       const upcomingDays = ds.upcoming_days || 5;
-      const members = Array.isArray(ds.members) ? ds.members : [];
+      const members = getAdminHouseholdMembers();
       const assistantInput = document.getElementById("settings-assistant-name");
       const memberInput = document.getElementById("settings-member-input");
       const calIdInput = document.getElementById("settings-google-cal-id");
@@ -354,7 +377,7 @@
       }
     }
 
-    async function persistMemberList(updatedMembers, successMessage) {
+    async function addHouseholdMember(displayName, successMessage) {
       const client = getSupabaseClient();
       if (!client) {
         showToast(friendlySaveMessage());
@@ -370,27 +393,30 @@
         addButton.disabled = true;
         addButton.textContent = "Saving\u2026";
       }
-      renderSettingsMembersList(adminHouseholdSettings.display_settings.members || []);
+      renderSettingsMembersList(getAdminHouseholdMembers());
 
       try {
-        const newDisplaySettings = {
-          ...adminHouseholdSettings.display_settings,
-          members: updatedMembers
-        };
-
-        const { error } = await client
-          .from("households")
-          .update({ display_settings: newDisplaySettings })
-          .eq("id", getAdminHouseholdId());
+        const { data, error } = await client
+          .from("household_members")
+          .insert({
+            household_id: getAdminHouseholdId(),
+            display_name: displayName,
+            color: getNextHouseholdMemberColor(getAdminHouseholdMembers())
+          })
+          .select("id, display_name, color, is_active, created_at")
+          .single();
 
         if (error) {
           showToast(friendlySaveMessage());
           return false;
         }
 
-        adminHouseholdSettings.display_settings = newDisplaySettings;
+        adminHouseholdSettings.household_members = normalizeHouseholdMembers([
+          ...getAdminHouseholdMembers(),
+          data
+        ]).sort((left, right) => left.display_name.localeCompare(right.display_name));
         pendingMemberRemovalIndex = null;
-        renderSettingsMembersList(updatedMembers);
+        renderSettingsMembersList(getAdminHouseholdMembers());
         showToast(successMessage);
         return true;
       } finally {
@@ -399,7 +425,43 @@
           addButton.disabled = false;
           addButton.textContent = "Save";
         }
-        renderSettingsMembersList(adminHouseholdSettings.display_settings.members || []);
+        renderSettingsMembersList(getAdminHouseholdMembers());
+      }
+    }
+
+    async function deactivateHouseholdMember(member, successMessage) {
+      const client = getSupabaseClient();
+      if (!client) {
+        showToast(friendlySaveMessage());
+        return false;
+      }
+      if (membersSavePending || !adminHouseholdConfigLoaded || !member?.id) {
+        return false;
+      }
+
+      membersSavePending = true;
+      renderSettingsMembersList(getAdminHouseholdMembers());
+
+      try {
+        const { error } = await client
+          .from("household_members")
+          .update({ is_active: false })
+          .eq("id", member.id)
+          .eq("household_id", getAdminHouseholdId());
+
+        if (error) {
+          showToast(friendlySaveMessage());
+          return false;
+        }
+
+        adminHouseholdSettings.household_members = getAdminHouseholdMembers().filter((existingMember) => existingMember.id !== member.id);
+        pendingMemberRemovalIndex = null;
+        renderSettingsMembersList(getAdminHouseholdMembers());
+        showToast(successMessage);
+        return true;
+      } finally {
+        membersSavePending = false;
+        renderSettingsMembersList(getAdminHouseholdMembers());
       }
     }
 
@@ -655,14 +717,14 @@
       const removeBtn = event.target.closest("[data-member-remove]");
       if (removeBtn) {
         pendingMemberRemovalIndex = parseInt(removeBtn.getAttribute("data-member-remove"), 10);
-        renderSettingsMembersList(adminHouseholdSettings.display_settings.members || []);
+        renderSettingsMembersList(getAdminHouseholdMembers());
         return;
       }
 
       const cancelBtn = event.target.closest("[data-member-cancel]");
       if (cancelBtn) {
         pendingMemberRemovalIndex = null;
-        renderSettingsMembersList(adminHouseholdSettings.display_settings.members || []);
+        renderSettingsMembersList(getAdminHouseholdMembers());
         return;
       }
 
@@ -670,12 +732,12 @@
       if (!confirmBtn) return;
 
       const idx = parseInt(confirmBtn.getAttribute("data-member-confirm"), 10);
-      const members = adminHouseholdSettings.display_settings.members || [];
-      if (!members[idx]) {
+      const members = getAdminHouseholdMembers();
+      const member = members[idx];
+      if (!member) {
         return;
       }
-      const updated = members.filter((_, i) => i !== idx);
-      persistMemberList(updated, `${members[idx].name} removed.`);
+      deactivateHouseholdMember(member, `${member.display_name} removed.`);
     }
 
     async function handleSettingsMemberAdd() {
@@ -684,15 +746,13 @@
       const name = input.value.trim();
       if (!name) return;
 
-      const members = adminHouseholdSettings.display_settings.members || [];
-      if (members.some((m) => m.name.toLowerCase() === name.toLowerCase())) {
+      const members = getAdminHouseholdMembers();
+      if (members.some((m) => m.display_name.toLowerCase() === name.toLowerCase())) {
         showToast(`"${name}" is already a member.`);
         return;
       }
 
-      const color = PERSON_COLOR_PALETTE[members.length % PERSON_COLOR_PALETTE.length];
-      const updated = [...members, { name, color }];
-      const didSave = await persistMemberList(updated, `${name} added.`);
+      const didSave = await addHouseholdMember(name, `${name} added.`);
       if (didSave) {
         input.value = "";
         input.focus();

--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -52,6 +52,11 @@
         );
       }
 
+      const currentUserMemberId = String(adminCurrentUser?.member_id || "").trim();
+      if (currentUserMemberId) {
+        linkedMemberIds.add(currentUserMemberId);
+      }
+
       const householdMembers = normalizedMembers.map((member) => ({
         ...member,
         has_linked_login: linkedMemberIds.has(member.id)
@@ -173,7 +178,7 @@
       }
 
       list.innerHTML = members.map((m, i) => `
-        ${pendingMemberRemovalIndex === i ? `
+        ${pendingMemberRemovalIndex === i && !m.has_linked_login ? `
           <div class="admin-settings-member-row admin-settings-member-row--confirm" data-member-index="${i}">
             <span class="admin-settings-member-confirm-text">Remove ${escapeHtml(m.display_name)}?</span>
             <div class="admin-settings-member-actions">
@@ -187,9 +192,11 @@
             <span class="admin-settings-member-name">${escapeHtml(m.display_name)}</span>
             <div class="admin-settings-member-actions">
               <span class="admin-pill${m.has_linked_login ? " admin-pill--member" : ""}">${m.has_linked_login ? "Has login" : "No login"}</span>
-              <button type="button" class="admin-settings-member-remove" data-member-remove="${i}" aria-label="Remove ${escapeHtml(m.display_name)}"${membersSavePending ? " disabled" : ""}>
-                <i data-lucide="x"></i>
-              </button>
+              ${m.has_linked_login ? "" : `
+                <button type="button" class="admin-settings-member-remove" data-member-remove="${i}" aria-label="Remove ${escapeHtml(m.display_name)}"${membersSavePending ? " disabled" : ""}>
+                  <i data-lucide="x"></i>
+                </button>
+              `}
             </div>
           </div>
         `}

--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -10,8 +10,7 @@
       const householdId = getAdminHouseholdId();
       const [
         { data, error },
-        { data: memberRows, error: memberError },
-        { data: userRows, error: userError }
+        { data: memberRows, error: memberError }
       ] = await Promise.all([
         client
           .from("households")
@@ -23,25 +22,37 @@
           .select("id, display_name, color, is_active, created_at")
           .eq("household_id", householdId)
           .eq("is_active", true)
-          .order("display_name", { ascending: true }),
-        client
-          .from("users")
-          .select("member_id")
-          .eq("household_id", householdId)
+          .order("display_name", { ascending: true })
       ]);
 
-      if (error || !data || memberError || userError) {
+      if (error || !data || memberError) {
         throw new Error("Failed to load household config");
       }
 
       const ds = normalizeDisplaySettings(data.display_settings);
       ds.members = Array.isArray(data.display_settings?.members) ? data.display_settings.members : [];
-      const linkedMemberIds = new Set(
-        Array.isArray(userRows)
-          ? userRows.map((row) => String(row?.member_id || "").trim()).filter(Boolean)
-          : []
-      );
-      const householdMembers = normalizeHouseholdMembers(memberRows).map((member) => ({
+      const normalizedMembers = normalizeHouseholdMembers(memberRows);
+      const memberIds = normalizedMembers.map((member) => member.id).filter(Boolean);
+      let linkedMemberIds = new Set();
+
+      if (memberIds.length) {
+        const { data: userRows, error: userError } = await client
+          .from("users")
+          .select("member_id")
+          .in("member_id", memberIds);
+
+        if (userError) {
+          throw new Error("Failed to load household config");
+        }
+
+        linkedMemberIds = new Set(
+          Array.isArray(userRows)
+            ? userRows.map((row) => String(row?.member_id || "").trim()).filter(Boolean)
+            : []
+        );
+      }
+
+      const householdMembers = normalizedMembers.map((member) => ({
         ...member,
         has_linked_login: linkedMemberIds.has(member.id)
       }));
@@ -612,6 +623,15 @@
         if (error || !data) {
           showToast(friendlySaveMessage());
         } else {
+          if (adminCurrentUser?.member_id) {
+            try {
+              await client
+                .from("household_members")
+                .update({ display_name: nextDisplayName })
+                .eq("id", adminCurrentUser.member_id);
+            } catch {}
+          }
+
           adminCurrentUser = {
             ...adminCurrentUser,
             displayName: data.display_name || "",

--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -8,59 +8,30 @@
       }
 
       const householdId = getAdminHouseholdId();
-      const [
-        { data, error },
-        { data: memberRows, error: memberError }
-      ] = await Promise.all([
-        client
-          .from("households")
-          .select("assistant_name, color_scheme, google_cal_id, display_settings")
-          .eq("id", householdId)
-          .single(),
-        client
-          .from("household_members")
-          .select("id, display_name, color, is_active, created_at")
-          .eq("household_id", householdId)
-          .eq("is_active", true)
-          .order("display_name", { ascending: true })
-      ]);
+      const { data, error } = await client
+        .from("households")
+        .select("assistant_name, color_scheme, google_cal_id, display_settings")
+        .eq("id", householdId)
+        .single();
 
-      if (error || !data || memberError) {
+      if (error || !data) {
+        throw new Error("Failed to load household config");
+      }
+
+      const {
+        data: memberRows,
+        error: memberError
+      } = await client.rpc("get_household_members_with_login_status", {
+        target_household_id: householdId
+      });
+
+      if (memberError) {
         throw new Error("Failed to load household config");
       }
 
       const ds = normalizeDisplaySettings(data.display_settings);
       ds.members = Array.isArray(data.display_settings?.members) ? data.display_settings.members : [];
-      const normalizedMembers = normalizeHouseholdMembers(memberRows);
-      const memberIds = normalizedMembers.map((member) => member.id).filter(Boolean);
-      let linkedMemberIds = new Set();
-
-      if (memberIds.length) {
-        const { data: userRows, error: userError } = await client
-          .from("users")
-          .select("member_id")
-          .in("member_id", memberIds);
-
-        if (userError) {
-          throw new Error("Failed to load household config");
-        }
-
-        linkedMemberIds = new Set(
-          Array.isArray(userRows)
-            ? userRows.map((row) => String(row?.member_id || "").trim()).filter(Boolean)
-            : []
-        );
-      }
-
-      const currentUserMemberId = String(adminCurrentUser?.member_id || "").trim();
-      if (currentUserMemberId) {
-        linkedMemberIds.add(currentUserMemberId);
-      }
-
-      const householdMembers = normalizedMembers.map((member) => ({
-        ...member,
-        has_linked_login: linkedMemberIds.has(member.id)
-      }));
+      const householdMembers = normalizeHouseholdMembers(memberRows);
 
       adminHouseholdSettings = {
         assistant_name: data.assistant_name || "",

--- a/js/admin-todos.js
+++ b/js/admin-todos.js
@@ -433,13 +433,19 @@
       const title = String(formData.get("title") || "").trim();
       const description = String(formData.get("description") || "").trim();
       const selectedAssigneeId = String(formData.get("assignee") || "").trim();
-      const legacyAssignee = String(formData.get("legacy_assignee") || "").trim();
       const dueDate = String(formData.get("due_date") || "").trim();
-      const assigneeMember = getHouseholdMemberById(getAdminHouseholdMembers(), selectedAssigneeId);
-      const assigneeMemberId = assigneeMember ? assigneeMember.id : null;
-      const assignee = assigneeMember
-        ? assigneeMember.display_name
-        : (legacyAssignee || null);
+      let assigneeMemberId = null;
+      let assignee = null;
+      if (selectedAssigneeId === "") {
+        assigneeMemberId = null;
+        assignee = null;
+      } else {
+        const assigneeMember = getHouseholdMemberById(getAdminHouseholdMembers(), selectedAssigneeId);
+        if (assigneeMember) {
+          assigneeMemberId = assigneeMember.id;
+          assignee = assigneeMember.display_name;
+        }
+      }
 
       if (!title || adminTodoWritePending) {
         return;
@@ -488,13 +494,19 @@
       const title = String(formData.get("title") || "").trim();
       const description = String(formData.get("description") || "").trim();
       const selectedAssigneeId = String(formData.get("assignee") || "").trim();
-      const legacyAssignee = String(formData.get("legacy_assignee") || "").trim();
       const dueDate = String(formData.get("due_date") || "").trim();
-      const assigneeMember = getHouseholdMemberById(getAdminHouseholdMembers(), selectedAssigneeId);
-      const assigneeMemberId = assigneeMember ? assigneeMember.id : null;
-      const assignee = assigneeMember
-        ? assigneeMember.display_name
-        : (legacyAssignee || null);
+      let assigneeMemberId = null;
+      let assignee = null;
+      if (selectedAssigneeId === "") {
+        assigneeMemberId = null;
+        assignee = null;
+      } else {
+        const assigneeMember = getHouseholdMemberById(getAdminHouseholdMembers(), selectedAssigneeId);
+        if (assigneeMember) {
+          assigneeMemberId = assigneeMember.id;
+          assignee = assigneeMember.display_name;
+        }
+      }
 
       if (!title || adminTodoWritePending) return;
 

--- a/js/admin-todos.js
+++ b/js/admin-todos.js
@@ -121,6 +121,14 @@
       }).format(completedDate)}`;
     }
 
+    function getAdminTodoAssigneeDisplay(todo) {
+      return resolveTodoAssignee(
+        getAdminHouseholdMembers(),
+        todo?.assignee_member_id,
+        todo?.assignee || ""
+      );
+    }
+
     function buildArchivedTodoDetailModalHTML(todo) {
       const notes = String(todo?.description || "").trim();
       const completionLabel = formatAdminTodoCompletionLabel(todo) || "Completed date unavailable";
@@ -143,11 +151,12 @@
         `);
       }
 
-      if (todo?.assignee) {
+      const assignee = getAdminTodoAssigneeDisplay(todo);
+      if (assignee?.name) {
         rows.push(`
           <div class="admin-detail-row">
             <span class="admin-detail-label">Assignee</span>
-            <span class="admin-detail-value">${escapeHtml(todo.assignee)}</span>
+            <span class="admin-detail-value">${escapeHtml(assignee.name)}</span>
           </div>
         `);
       }
@@ -223,7 +232,8 @@
 
     function renderAdminTodoCard(todo, options) {
       const title = escapeHtml(todo.title || "Untitled task");
-      const assignee = todo.assignee ? escapeHtml(todo.assignee) : "Unassigned";
+      const assignee = getAdminTodoAssigneeDisplay(todo);
+      const assigneeLabel = assignee?.name || "Unassigned";
       const hasDescription = !!String(todo.description || "").trim();
       const overdueClass = options.showComplete && isTodoOverdue(todo.due_date)
         ? " admin-todo-card--overdue"
@@ -256,7 +266,7 @@
       ` : "";
       const meta = `
         <div class="admin-todo-meta">
-          ${buildAdminAssigneePill(assignee)}
+          ${buildAdminAssigneePill(assigneeLabel, assignee?.id || todo.assignee_member_id || "")}
           ${dueMarkup}
         </div>
       `;
@@ -422,8 +432,14 @@
 
       const title = String(formData.get("title") || "").trim();
       const description = String(formData.get("description") || "").trim();
-      const assignee = String(formData.get("assignee") || "").trim();
+      const selectedAssigneeId = String(formData.get("assignee") || "").trim();
+      const legacyAssignee = String(formData.get("legacy_assignee") || "").trim();
       const dueDate = String(formData.get("due_date") || "").trim();
+      const assigneeMember = getHouseholdMemberById(getAdminHouseholdMembers(), selectedAssigneeId);
+      const assigneeMemberId = assigneeMember ? assigneeMember.id : null;
+      const assignee = assigneeMember
+        ? assigneeMember.display_name
+        : (legacyAssignee || null);
 
       if (!title || adminTodoWritePending) {
         return;
@@ -443,6 +459,7 @@
           household_id: getAdminHouseholdId(),
           title,
           description: description || null,
+          assignee_member_id: assigneeMemberId,
           assignee: assignee || null,
           due_date: dueDate || null,
           recurrence_type: recurrenceData.recurrence_type,
@@ -470,8 +487,14 @@
 
       const title = String(formData.get("title") || "").trim();
       const description = String(formData.get("description") || "").trim();
-      const assignee = String(formData.get("assignee") || "").trim();
+      const selectedAssigneeId = String(formData.get("assignee") || "").trim();
+      const legacyAssignee = String(formData.get("legacy_assignee") || "").trim();
       const dueDate = String(formData.get("due_date") || "").trim();
+      const assigneeMember = getHouseholdMemberById(getAdminHouseholdMembers(), selectedAssigneeId);
+      const assigneeMemberId = assigneeMember ? assigneeMember.id : null;
+      const assignee = assigneeMember
+        ? assigneeMember.display_name
+        : (legacyAssignee || null);
 
       if (!title || adminTodoWritePending) return;
 
@@ -488,6 +511,7 @@
         .update({
           title,
           description: description || null,
+          assignee_member_id: assigneeMemberId,
           assignee: assignee || null,
           due_date: dueDate || null,
           recurrence_type: recurrenceData.recurrence_type,
@@ -512,16 +536,22 @@
 
     function buildTodoFormHTML(todo) {
       const isEdit = !!todo;
-      const currentAssignee = isEdit ? (todo.assignee || "") : "";
-      // Read members from settings
-      const memberNames = (adminHouseholdSettings.display_settings.members || []).map((m) => m.name);
-      // Preserve any existing assignee that isn't in the current list (e.g. old data)
-      const extraMember = currentAssignee && !memberNames.includes(currentAssignee)
-        ? [currentAssignee]
-        : [];
-      const assigneeOptions = ["", ...memberNames, ...extraMember].map((name) =>
-        `<option value="${escapeHtml(name)}"${name === currentAssignee ? " selected" : ""}>${escapeHtml(name || "Unassigned")}</option>`
-      ).join("");
+      const currentAssignee = getAdminTodoAssigneeDisplay(todo);
+      const currentAssigneeId = isEdit ? String(todo.assignee_member_id || "").trim() : "";
+      const members = getAdminHouseholdMembers();
+      const selectedMemberStillActive = currentAssigneeId && getHouseholdMemberById(members, currentAssigneeId);
+      const needsLegacyOption = isEdit && !currentAssigneeId && currentAssignee?.name && !getHouseholdMemberByName(members, currentAssignee.name);
+      const needsInactiveMemberOption = isEdit && currentAssigneeId && !selectedMemberStillActive && currentAssignee?.name;
+      const assigneeOptions = [
+        `<option value="">Unassigned</option>`,
+        ...members.map((member) => `<option value="${escapeHtml(member.id)}"${member.id === currentAssigneeId ? " selected" : ""}>${escapeHtml(member.display_name)}</option>`),
+        needsInactiveMemberOption
+          ? `<option value="${escapeHtml(currentAssigneeId)}" selected>${escapeHtml(`${currentAssignee.name} (inactive)`)}</option>`
+          : "",
+        needsLegacyOption
+          ? `<option value="__legacy__" selected>${escapeHtml(`${currentAssignee.name} (legacy)`)}</option>`
+          : ""
+      ].filter(Boolean).join("");
 
       // Recurrence pre-population
       const recurrenceEnabled = isEdit && !!todo.recurrence_type;
@@ -579,6 +609,7 @@
               <select id="modal-todo-assignee" name="assignee">
                 ${assigneeOptions}
               </select>
+              ${(needsLegacyOption || needsInactiveMemberOption) ? `<input type="hidden" name="legacy_assignee" value="${escapeHtml(currentAssignee?.name || "")}">` : ""}
             </div>
             <div class="admin-field">
               <label for="modal-todo-due" id="modal-todo-due-label">${recurrenceEnabled ? "First due date" : "Due date"}</label>
@@ -923,6 +954,7 @@
             household_id: getAdminHouseholdId(),
             title: todo.title,
             description: todo.description || null,
+            assignee_member_id: todo.assignee_member_id || null,
             assignee: todo.assignee || null,
             recurrence_type: todo.recurrence_type,
             recurrence_config: todo.recurrence_config,
@@ -1057,7 +1089,7 @@
 
       const { data, error } = await client
         .from("todos")
-        .select("id, title, description, assignee, due_date, archived_at, completed_at, deleted_at, created_at, recurrence_type, recurrence_config, recurrence_template_id")
+        .select("id, title, description, assignee, assignee_member_id, due_date, archived_at, completed_at, deleted_at, created_at, recurrence_type, recurrence_config, recurrence_template_id")
         .eq("household_id", getAdminHouseholdId())
         .order("due_date", { ascending: true, nullsFirst: false })
         .order("created_at", { ascending: true });
@@ -1248,6 +1280,7 @@
           household_id: getAdminHouseholdId(),
           title: todo.title,
           description: todo.description || null,
+          assignee_member_id: todo.assignee_member_id || null,
           assignee: todo.assignee || null,
           recurrence_type: todo.recurrence_type,
           recurrence_config: todo.recurrence_config,

--- a/js/display-calendar.js
+++ b/js/display-calendar.js
@@ -368,7 +368,7 @@
       ]);
 
       cachedHouseholdConfig = householdConfig;
-      cachedDisplayHouseholdMembers = householdMembers || [];
+      cachedDisplayHouseholdMembers = householdMembers;
       cachedSupabaseCountdowns = supabaseCountdowns;
 
       updateHouseholdName(householdConfig);

--- a/js/display-calendar.js
+++ b/js/display-calendar.js
@@ -361,12 +361,14 @@
       markPending("calendar");
       markPending("countdowns");
 
-      const [householdConfig, supabaseCountdowns] = await Promise.all([
+      const [householdConfig, householdMembers, supabaseCountdowns] = await Promise.all([
         fetchHouseholdConfig(),
+        fetchHouseholdMembers(),
         fetchCountdowns()
       ]);
 
       cachedHouseholdConfig = householdConfig;
+      cachedDisplayHouseholdMembers = householdMembers || [];
       cachedSupabaseCountdowns = supabaseCountdowns;
 
       updateHouseholdName(householdConfig);

--- a/js/display-core.js
+++ b/js/display-core.js
@@ -24,6 +24,7 @@
 
     let calendarEventsMap = new Map();
     let cachedHouseholdConfig = null;
+    let cachedDisplayHouseholdMembers = [];
     let cachedDisplayTodos = null;
     let cachedSupabaseCountdowns = null;
     let cachedCalendarCountdowns = [];
@@ -523,16 +524,29 @@
       `;
     }
 
-    function getAssigneeMarkup(assignee) {
-      const memberColor = getConfiguredMemberColor(cachedHouseholdConfig?.display_settings?.members, assignee);
+    function getDisplayHouseholdMembers() {
+      if (Array.isArray(cachedDisplayHouseholdMembers) && cachedDisplayHouseholdMembers.length > 0) {
+        return cachedDisplayHouseholdMembers;
+      }
+
+      return normalizeHouseholdMembers(cachedHouseholdConfig?.display_settings?.members || []);
+    }
+
+    function getAssigneeMarkup(assignee, assigneeMemberId = "") {
+      const resolvedAssignee = resolveTodoAssignee(getDisplayHouseholdMembers(), assigneeMemberId, assignee);
+      if (!resolvedAssignee?.name) {
+        return "";
+      }
+
+      const memberColor = String(resolvedAssignee.color || "").trim();
 
       if (!memberColor) {
-        return `<span class="todo-assignee todo-assignee--other">${escapeHtml(assignee)}</span>`;
+        return `<span class="todo-assignee todo-assignee--other">${escapeHtml(resolvedAssignee.name)}</span>`;
       }
 
       return `
         <span class="todo-assignee todo-assignee--custom" style="background:${escapeHtml(hexToRgba(memberColor, 0.16))};color:${escapeHtml(memberColor)}">
-          ${escapeHtml(assignee)}
+          ${escapeHtml(resolvedAssignee.name)}
         </span>
       `;
     }

--- a/js/display-core.js
+++ b/js/display-core.js
@@ -24,7 +24,7 @@
 
     let calendarEventsMap = new Map();
     let cachedHouseholdConfig = null;
-    let cachedDisplayHouseholdMembers = [];
+    let cachedDisplayHouseholdMembers = null;
     let cachedDisplayTodos = null;
     let cachedSupabaseCountdowns = null;
     let cachedCalendarCountdowns = [];
@@ -525,7 +525,7 @@
     }
 
     function getDisplayHouseholdMembers() {
-      if (Array.isArray(cachedDisplayHouseholdMembers) && cachedDisplayHouseholdMembers.length > 0) {
+      if (cachedDisplayHouseholdMembers !== null) {
         return cachedDisplayHouseholdMembers;
       }
 

--- a/js/display-init.js
+++ b/js/display-init.js
@@ -423,8 +423,13 @@
           renderRsvpBoardWithData();
         }
         Promise.allSettled([fetchTodos(), fetchMeals(), fetchWeeklyNote(), fetchHouseholdMembers()]).then(([todosResult, mealsResult, noteResult, membersResult]) => {
-          if (membersResult.status === "fulfilled" && membersResult.value !== null) {
+          if (membersResult.status === "fulfilled") {
             cachedDisplayHouseholdMembers = membersResult.value;
+            if (cachedDisplayTodos !== null) {
+              renderTodoItems(cachedDisplayTodos);
+            }
+          } else {
+            cachedDisplayHouseholdMembers = null;
             if (cachedDisplayTodos !== null) {
               renderTodoItems(cachedDisplayTodos);
             }

--- a/js/display-init.js
+++ b/js/display-init.js
@@ -422,7 +422,13 @@
         if (!shouldHideRsvpScreen() && track.querySelector(".rsvp-screen")) {
           renderRsvpBoardWithData();
         }
-        Promise.allSettled([fetchTodos(), fetchMeals(), fetchWeeklyNote()]).then(([todosResult, mealsResult, noteResult]) => {
+        Promise.allSettled([fetchTodos(), fetchMeals(), fetchWeeklyNote(), fetchHouseholdMembers()]).then(([todosResult, mealsResult, noteResult, membersResult]) => {
+          if (membersResult.status === "fulfilled" && membersResult.value !== null) {
+            cachedDisplayHouseholdMembers = membersResult.value;
+            if (cachedDisplayTodos !== null) {
+              renderTodoItems(cachedDisplayTodos);
+            }
+          }
           if (todosResult.status === "fulfilled" && todosResult.value !== null) renderTodoItems(todosResult.value);
           if (noteResult.status === "fulfilled" && noteResult.value !== null) lastWeeklyNote = noteResult.value;
           if (mealsResult.status === "fulfilled" && mealsResult.value !== null) renderMeals(mealsResult.value, lastWeeklyNote);

--- a/js/display-sync.js
+++ b/js/display-sync.js
@@ -31,9 +31,11 @@
           fetchDisplayScorecards()
         ]);
 
-        cachedDisplayHouseholdMembers = newMembers;
-        if (cachedDisplayTodos !== null) {
-          renderTodoItems(cachedDisplayTodos);
+        if (newMembers !== null) {
+          cachedDisplayHouseholdMembers = newMembers;
+          if (cachedDisplayTodos !== null) {
+            renderTodoItems(cachedDisplayTodos);
+          }
         }
 
         if (newConfig) {

--- a/js/display-sync.js
+++ b/js/display-sync.js
@@ -24,11 +24,16 @@
         if (remoteMeals !== null) renderMeals(remoteMeals, weeklyNote || "");
 
         // Re-fetch calendar (wide fetch refreshes countdowns too)
-        const [newConfig, newSupabaseCountdowns, newScorecards] = await Promise.all([
+        const [newConfig, newMembers, newSupabaseCountdowns, newScorecards] = await Promise.all([
           fetchHouseholdConfig(),
+          fetchHouseholdMembers(),
           fetchCountdowns(),
           fetchDisplayScorecards()
         ]);
+
+        if (newMembers !== null) {
+          cachedDisplayHouseholdMembers = newMembers;
+        }
 
         if (newConfig) {
           cachedHouseholdConfig = newConfig;

--- a/js/display-sync.js
+++ b/js/display-sync.js
@@ -31,8 +31,9 @@
           fetchDisplayScorecards()
         ]);
 
-        if (newMembers !== null) {
-          cachedDisplayHouseholdMembers = newMembers;
+        cachedDisplayHouseholdMembers = newMembers;
+        if (cachedDisplayTodos !== null) {
+          renderTodoItems(cachedDisplayTodos);
         }
 
         if (newConfig) {

--- a/js/display-todos.js
+++ b/js/display-todos.js
@@ -4,6 +4,7 @@
         id: todo.id,
         title: todo.title || "Untitled task",
         assignee: todo.assignee || "",
+        assigneeMemberId: todo.assignee_member_id || "",
         description: description || null,
         dueDate: todo.due_date || null,
         duePill: getTodoDuePill(todo.due_date),
@@ -529,7 +530,9 @@
         const pill = todo.duePill
           ? `<span class="todo-due-pill ${escapeHtml(todo.duePill.cssClass)}">${escapeHtml(todo.duePill.label)}</span>`
           : "";
-        const assignee = todo.assignee ? getAssigneeMarkup(todo.assignee) : "";
+        const assignee = (todo.assignee || todo.assigneeMemberId)
+          ? getAssigneeMarkup(todo.assignee, todo.assigneeMemberId)
+          : "";
         const overdueClass = todo.isOverdue ? " todo-card--overdue" : "";
         const infoIcon = todo.description
           ? `<span class="todo-detail-indicator" aria-hidden="true"><i data-lucide="info"></i></span>`
@@ -636,13 +639,14 @@
             household_id: getDisplayHouseholdId(),
             title: todo.title,
             description: todo.description || null,
+            assignee_member_id: todo.assigneeMemberId || null,
             assignee: todo.assignee || null,
             recurrence_type: todo.recurrenceType,
             recurrence_config: todo.recurrenceConfig,
             recurrence_template_id: templateId,
             due_date: nextDueDate
           })
-          .select("id, title, description, due_date, assignee, recurrence_type, recurrence_config, recurrence_template_id")
+          .select("id, title, description, due_date, assignee, assignee_member_id, recurrence_type, recurrence_config, recurrence_template_id")
           .single();
 
         if (insertError) {
@@ -683,7 +687,7 @@
 
       const { data, error } = await client
         .from("todos")
-        .select("id, title, description, due_date, assignee, archived_at, created_at, recurrence_type, recurrence_config, recurrence_template_id")
+        .select("id, title, description, due_date, assignee, assignee_member_id, archived_at, created_at, recurrence_type, recurrence_config, recurrence_template_id")
         .eq("household_id", getDisplayHouseholdId())
         .is("archived_at", null)
         .is("deleted_at", null)

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.21";
+    const VERSION = "2.0.22";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.25";
+    const VERSION = "2.0.26";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.22";
+    const VERSION = "2.0.23";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.24";
+    const VERSION = "2.0.25";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.23";
+    const VERSION = "2.0.24";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.20";
+    const VERSION = "2.0.21";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");
@@ -245,6 +245,68 @@
       );
 
       return String(match?.color || "").trim();
+    }
+
+    function normalizeHouseholdMembers(members) {
+      if (!Array.isArray(members)) {
+        return [];
+      }
+
+      return members
+        .map((member) => ({
+          id: String(member?.id || "").trim(),
+          display_name: String(member?.display_name || member?.name || "").trim(),
+          color: String(member?.color || "").trim(),
+          is_active: member?.is_active !== false,
+          has_linked_login: member?.has_linked_login === true
+        }))
+        .filter((member) => member.display_name);
+    }
+
+    function getHouseholdMemberById(members, memberId) {
+      const normalizedMembers = normalizeHouseholdMembers(members);
+      const normalizedId = String(memberId || "").trim();
+      if (!normalizedId) {
+        return null;
+      }
+
+      return normalizedMembers.find((member) => member.id === normalizedId) || null;
+    }
+
+    function getHouseholdMemberByName(members, name) {
+      const normalizedMembers = normalizeHouseholdMembers(members);
+      const normalizedName = String(name || "").trim().toLowerCase();
+      if (!normalizedName) {
+        return null;
+      }
+
+      return normalizedMembers.find((member) => member.display_name.toLowerCase() === normalizedName) || null;
+    }
+
+    function resolveTodoAssignee(members, assigneeMemberId, fallbackAssignee = "") {
+      const memberMatch = getHouseholdMemberById(members, assigneeMemberId)
+        || getHouseholdMemberByName(members, fallbackAssignee);
+
+      if (memberMatch) {
+        return {
+          id: memberMatch.id,
+          name: memberMatch.display_name,
+          color: memberMatch.color,
+          hasLinkedLogin: memberMatch.has_linked_login === true
+        };
+      }
+
+      const fallbackName = String(fallbackAssignee || "").trim();
+      if (!fallbackName) {
+        return null;
+      }
+
+      return {
+        id: "",
+        name: fallbackName,
+        color: "",
+        hasLinkedLogin: false
+      };
     }
 
     function formatLongDate(dateString) {
@@ -1543,6 +1605,32 @@
       }
 
       return data;
+    }
+
+    async function fetchHouseholdMembers(householdId = "") {
+      const client = getSupabaseClient();
+
+      if (!client) {
+        return null;
+      }
+
+      const id = String(householdId || (isAdminMode ? getAdminHouseholdId() : getDisplayHouseholdId()) || "").trim();
+      if (!id) {
+        return [];
+      }
+
+      const { data, error } = await client
+        .from("household_members")
+        .select("id, display_name, color, is_active, created_at")
+        .eq("household_id", id)
+        .eq("is_active", true)
+        .order("display_name", { ascending: true });
+
+      if (error || !Array.isArray(data)) {
+        return null;
+      }
+
+      return normalizeHouseholdMembers(data);
     }
 
     async function fetchGoogleCalendarEvents(calendarId, apiKey, timeMin, timeMax, maxResults = "250") {

--- a/supabase/functions/create-household-on-signup/index.ts
+++ b/supabase/functions/create-household-on-signup/index.ts
@@ -151,6 +151,7 @@ Deno.serve(async (request) => {
     .insert({
       household_id: household.id,
       display_name: displayName,
+      color: "#2563eb",
     })
     .select("id")
     .single();

--- a/supabase/migrations/20260417130000_add_todo_assignee_member_id.sql
+++ b/supabase/migrations/20260417130000_add_todo_assignee_member_id.sql
@@ -1,0 +1,12 @@
+ALTER TABLE todos
+ADD COLUMN IF NOT EXISTS assignee_member_id uuid REFERENCES household_members(id);
+
+UPDATE todos AS t
+SET assignee_member_id = hm.id
+FROM household_members AS hm
+JOIN households AS h
+  ON h.id = hm.household_id
+WHERE t.household_id = h.id
+  AND lower(t.assignee) = lower(hm.display_name)
+  AND hm.is_active = true
+  AND t.assignee_member_id IS NULL;

--- a/supabase/migrations/20260418113000_add_household_members_login_status_rpc.sql
+++ b/supabase/migrations/20260418113000_add_household_members_login_status_rpc.sql
@@ -1,0 +1,37 @@
+CREATE OR REPLACE FUNCTION public.get_household_members_with_login_status(target_household_id uuid)
+RETURNS TABLE (
+  id uuid,
+  display_name text,
+  color text,
+  is_active boolean,
+  created_at timestamptz,
+  has_linked_login boolean
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    hm.id,
+    hm.display_name,
+    hm.color,
+    hm.is_active,
+    hm.created_at,
+    EXISTS (
+      SELECT 1
+      FROM public.users AS u
+      WHERE u.member_id = hm.id
+    ) AS has_linked_login
+  FROM public.household_members AS hm
+  WHERE hm.household_id = target_household_id
+    AND hm.is_active = true
+    AND EXISTS (
+      SELECT 1
+      FROM public.users AS viewer
+      WHERE viewer.id = auth.uid()
+        AND viewer.household_id = target_household_id
+    )
+  ORDER BY hm.display_name;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_household_members_with_login_status(uuid) TO authenticated;

--- a/supabase/migrations/20260418143000_refine_todo_assignee_backfill.sql
+++ b/supabase/migrations/20260418143000_refine_todo_assignee_backfill.sql
@@ -1,0 +1,18 @@
+WITH canonical_members AS (
+  SELECT DISTINCT ON (hm.household_id, lower(hm.display_name))
+    hm.id,
+    hm.household_id,
+    lower(hm.display_name) AS display_name_key
+  FROM public.household_members AS hm
+  WHERE hm.is_active = true
+  ORDER BY hm.household_id, lower(hm.display_name), hm.created_at ASC, hm.id ASC
+)
+UPDATE public.todos AS t
+SET assignee_member_id = canonical_members.id
+FROM canonical_members
+WHERE t.household_id = canonical_members.household_id
+  AND lower(t.assignee) = canonical_members.display_name_key
+  AND t.assignee_member_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS todos_assignee_member_id_idx
+ON public.todos (assignee_member_id);

--- a/supabase/migrations/20260418143500_update_household_members_login_status_rpc.sql
+++ b/supabase/migrations/20260418143500_update_household_members_login_status_rpc.sql
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION public.get_household_members_with_login_status(target_household_id uuid)
+RETURNS TABLE (
+  id uuid,
+  display_name text,
+  color text,
+  is_active boolean,
+  created_at timestamptz,
+  has_linked_login boolean
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    hm.id,
+    hm.display_name,
+    hm.color,
+    hm.is_active,
+    hm.created_at,
+    EXISTS (
+      SELECT 1
+      FROM public.users AS u
+      WHERE u.member_id = hm.id
+    ) AS has_linked_login
+  FROM public.household_members AS hm
+  WHERE hm.household_id = target_household_id
+    AND hm.is_active = true
+    AND EXISTS (
+      SELECT 1
+      FROM public.users AS viewer
+      WHERE viewer.id = auth.uid()
+        AND viewer.household_id = target_household_id
+    )
+  ORDER BY lower(hm.display_name);
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_household_members_with_login_status(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_household_members_with_login_status(uuid) TO authenticated;

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.20";
+const CACHE_NAME = "homeboard-v2.0.21";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.21";
+const CACHE_NAME = "homeboard-v2.0.22";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.24";
+const CACHE_NAME = "homeboard-v2.0.25";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.23";
+const CACHE_NAME = "homeboard-v2.0.24";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.22";
+const CACHE_NAME = "homeboard-v2.0.23";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.25";
+const CACHE_NAME = "homeboard-v2.0.26";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary
- move admin member management to the household_members table and show linked-login status
- migrate todo assignment to assignee_member_id with household_members-backed admin/display resolution and legacy assignee fallback
- stop onboarding from mirroring members into display_settings.members, add the todos migration, and update docs/versioning

AI-assisted: Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Member-aware todo assignees (selectable by member) with inactive-member support and display adjustments.
  * Login-status indicators for household members and household-member caching for faster UI updates.
  * Safe-area-aware bottom padding for admin settings and service-worker cache version update.

* **Documentation**
  * Clarified schema notes: canonical household-member source, legacy fallbacks, and todo assignee fields/behavior.

* **Chores**
  * Bumped app version to 2.0.25 and added DB migration to store assignee member IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->