### PR TITLE
Restrict RSVP visibility to the wedding household

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -980,8 +980,7 @@
       right: 0;
       bottom: 0;
       z-index: 10;
-      display: grid;
-      grid-template-columns: repeat(5, minmax(0, 1fr));
+      display: flex;
       gap: 8px;
       padding: 10px 12px calc(10px + env(safe-area-inset-bottom));
       background: rgb(255, 250, 243);
@@ -994,6 +993,7 @@
       padding: 10px 4px;
       background: transparent;
       color: var(--muted);
+      flex: 1 1 0;
       display: grid;
       justify-items: center;
       align-items: center;

--- a/js/admin-core.js
+++ b/js/admin-core.js
@@ -1080,6 +1080,10 @@
     }
 
     function setAdminScreen(nextScreen) {
+      if (nextScreen === "rsvp" && !isRsvpDisplayScreenAvailable(getAdminHouseholdId())) {
+        nextScreen = "todos";
+      }
+
       adminScreen = nextScreen;
 
       adminScreens.forEach((screen) => {
@@ -1106,6 +1110,21 @@
         } else {
           adminSettingsButton.removeAttribute("aria-current");
         }
+      }
+    }
+
+    function syncAdminRsvpVisibility() {
+      const rsvpNavButton = document.querySelector("[data-admin-nav='rsvp']");
+      const rsvpScreen = document.querySelector("[data-admin-screen='rsvp']");
+      const rsvpEnabled = isRsvpDisplayScreenAvailable(getAdminHouseholdId());
+
+      if (rsvpNavButton) {
+        rsvpNavButton.hidden = !rsvpEnabled;
+      }
+
+      if (rsvpScreen && !rsvpEnabled) {
+        rsvpScreen.hidden = true;
+        rsvpScreen.classList.remove("is-active");
       }
     }
 
@@ -1179,6 +1198,7 @@
       if (adminUiStarted) return;
       adminUiStarted = true;
       applyAdminTheme(adminCurrentUser?.preferences?.admin_theme);
+      syncAdminRsvpVisibility();
       setAdminScreen("todos");
       adminNavButtons.forEach((button) => button.addEventListener("click", handleAdminNavClick));
       adminActiveList.addEventListener("click", handleAdminActiveListClick);

--- a/js/admin-core.js
+++ b/js/admin-core.js
@@ -223,11 +223,11 @@
     const TIMER_DEFAULTS = { upcoming_calendar: 30, monthly_calendar: 60, todos: 45, meals: 30, countdowns: 15, scorecards: 30, rsvp: 30 };
 
     function getAdminConfigurableScreens() {
-      return getConfigurableDisplayScreenKeys();
+      return getConfigurableDisplayScreenKeys(getAdminHouseholdId());
     }
 
     function getAdminTimerScreenKeys() {
-      return getConfigurableDisplayScreenKeys();
+      return getConfigurableDisplayScreenKeys(getAdminHouseholdId());
     }
 
     // Loaded from Supabase at admin init; falls back to defaults so todo form always works

--- a/js/admin-core.js
+++ b/js/admin-core.js
@@ -1120,15 +1120,20 @@
 
       if (rsvpNavButton) {
         rsvpNavButton.hidden = !rsvpEnabled;
+        rsvpNavButton.style.display = rsvpEnabled ? "" : "none";
       }
 
-      if (rsvpScreen && !rsvpEnabled) {
-        rsvpScreen.hidden = true;
-        rsvpScreen.classList.remove("is-active");
+      if (rsvpScreen) {
+        rsvpScreen.hidden = !rsvpEnabled || adminScreen !== "rsvp";
+        rsvpScreen.style.display = rsvpEnabled ? "" : "none";
+        if (!rsvpEnabled) {
+          rsvpScreen.classList.remove("is-active");
+        }
       }
     }
 
     function openAdminSettings() {
+      syncAdminRsvpVisibility();
       setAdminScreen("settings");
       renderAdminSettingsSkeleton();
       loadAdminAccountSettings();

--- a/js/admin-rsvp.js
+++ b/js/admin-rsvp.js
@@ -403,6 +403,15 @@
     }
 
     async function loadAdminRsvpScreen() {
+      if (!isRsvpDisplayScreenAvailable(getAdminHouseholdId())) {
+        adminWeddingSnapshot = null;
+        adminRsvpUnmatchedNote.textContent = "";
+        adminRsvpGuestListNote.textContent = "";
+        adminRsvpUnmatchedList.innerHTML = "";
+        adminRsvpGuestList.innerHTML = "";
+        return;
+      }
+
       adminRsvpUnmatchedNote.textContent = "Loading RSVP matches\u2026";
       adminRsvpGuestListNote.textContent = "Loading invited parties\u2026";
       adminRsvpUnmatchedList.innerHTML = buildAdminRsvpReviewSkeletonHTML();

--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -253,7 +253,9 @@
 
       const ds = adminHouseholdSettings.display_settings || {};
       const configurableScreens = getAdminConfigurableScreens();
-      const activeScreens = Array.isArray(ds.active_screens) ? ds.active_screens : configurableScreens;
+      const activeScreens = Array.isArray(ds.active_screens)
+        ? ds.active_screens.filter((name) => configurableScreens.includes(name))
+        : configurableScreens;
       const screenOrder = normalizeAdminScreenOrder(Array.isArray(ds.screen_order) ? ds.screen_order : configurableScreens);
       const timerIntervals = ds.timer_intervals || {};
       const upcomingDays = ds.upcoming_days || 5;
@@ -269,9 +271,15 @@
         }
       });
 
-      const rsvpToggle = document.querySelector("[name='screen_rsvp']")?.closest(".admin-settings-toggle");
+      const rsvpCheckbox = document.querySelector("[name='screen_rsvp']");
+      const rsvpToggle = rsvpCheckbox?.closest(".admin-settings-toggle");
+      const rsvpEnabled = configurableScreens.includes("rsvp");
+      if (rsvpCheckbox) {
+        rsvpCheckbox.checked = rsvpEnabled && activeScreens.includes("rsvp");
+        rsvpCheckbox.disabled = !rsvpEnabled;
+      }
       if (rsvpToggle) {
-        rsvpToggle.hidden = !configurableScreens.includes("rsvp");
+        rsvpToggle.hidden = !rsvpEnabled;
       }
 
       // Household
@@ -785,7 +793,8 @@
     }
 
     function enforceMinOneActiveScreen() {
-      const checkboxes = Array.from(document.querySelectorAll("#settings-screen-toggles [type='checkbox']"));
+      const checkboxes = Array.from(document.querySelectorAll("#settings-screen-toggles [type='checkbox']"))
+        .filter((cb) => !cb.closest(".admin-settings-toggle")?.hidden);
       const checkedBoxes = checkboxes.filter((cb) => cb.checked);
       checkboxes.forEach((cb) => {
         // Disable the last checked box so the user can't uncheck it

--- a/js/admin-settings.js
+++ b/js/admin-settings.js
@@ -280,6 +280,7 @@
       }
       if (rsvpToggle) {
         rsvpToggle.hidden = !rsvpEnabled;
+        rsvpToggle.style.display = rsvpEnabled ? "" : "none";
       }
 
       // Household

--- a/js/display-core.js
+++ b/js/display-core.js
@@ -443,6 +443,7 @@
 
     function getDisplayNavItems() {
       const visibleScreens = getOrderedVisibleScreenEntries();
+      const rsvpEnabled = isRsvpDisplayScreenAvailable(getDisplayHouseholdId());
       const visibleIndexByKey = new Map();
       visibleScreens.forEach((entry, index) => {
         const screenKey = entry.groupKey;
@@ -457,6 +458,9 @@
 
       configuredOrder.forEach((screenKey) => {
         const normalizedKey = isScorecardScreenKey(screenKey) ? "scorecards" : screenKey;
+        if (normalizedKey === "rsvp" && !rsvpEnabled) {
+          return;
+        }
         const targetIndex = visibleIndexByKey.get(normalizedKey);
         if (targetIndex === undefined || seen.has(normalizedKey)) {
           return;
@@ -474,6 +478,9 @@
 
       visibleScreens.forEach((entry, index) => {
         const screenKey = entry.groupKey;
+        if (screenKey === "rsvp" && !rsvpEnabled) {
+          return;
+        }
         if (seen.has(screenKey)) {
           return;
         }
@@ -672,11 +679,14 @@
     function applyActiveScreens(activeScreens) {
       const normalizedScreens = Array.isArray(activeScreens) ? activeScreens : [];
       const hasIndividualScorecardFlags = normalizedScreens.some((key) => isScorecardScreenKey(key));
+      const rsvpEnabled = isRsvpDisplayScreenAvailable(getDisplayHouseholdId());
       DISPLAY_SCREEN_KEYS.forEach((name) => {
         getRegisteredScreens(name).forEach((screen) => {
           const isEnabled = name === "scorecards"
             ? normalizedScreens.includes("scorecards")
               && (!hasIndividualScorecardFlags || normalizedScreens.includes(buildScorecardScreenKey(screen.dataset.scorecardId)))
+            : name === "rsvp"
+              ? normalizedScreens.includes("rsvp") && rsvpEnabled
             : normalizedScreens.includes(name);
           if (isEnabled) {
             screen.classList.remove("screen--disabled");

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.29";
+    const VERSION = "2.0.30";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.26";
+    const VERSION = "2.0.27";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");
@@ -45,6 +45,7 @@
 
     const TODO_HOUSEHOLD_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
     const DISPLAY_HOUSEHOLD_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    const RSVP_HOUSEHOLD_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
 
     function getDisplayHouseholdId() {
       try {
@@ -381,7 +382,23 @@
       return [screenKey];
     }
 
-    function isRsvpDisplayScreenAvailable(referenceDate = new Date()) {
+    function isRsvpHouseholdId(householdId) {
+      return String(householdId || "").trim() === RSVP_HOUSEHOLD_ID;
+    }
+
+    function getRsvpFeatureHouseholdId() {
+      if (isAdminMode && typeof getAdminHouseholdId === "function") {
+        return getAdminHouseholdId();
+      }
+
+      return getDisplayHouseholdId();
+    }
+
+    function isRsvpDisplayScreenAvailable(householdId = getRsvpFeatureHouseholdId(), referenceDate = new Date()) {
+      if (!isRsvpHouseholdId(householdId)) {
+        return false;
+      }
+
       const date = referenceDate instanceof Date ? new Date(referenceDate) : new Date(referenceDate);
       if (Number.isNaN(date.getTime())) {
         return true;
@@ -391,8 +408,8 @@
       return formatDateKey(date) <= RSVP_RETIRE_AFTER_DATE;
     }
 
-    function getConfigurableDisplayScreenKeys(referenceDate = new Date()) {
-      return DISPLAY_SCREEN_KEYS.filter((key) => key !== "rsvp" || isRsvpDisplayScreenAvailable(referenceDate));
+    function getConfigurableDisplayScreenKeys(householdId = getRsvpFeatureHouseholdId(), referenceDate = new Date()) {
+      return DISPLAY_SCREEN_KEYS.filter((key) => key !== "rsvp" || isRsvpDisplayScreenAvailable(householdId, referenceDate));
     }
 
     function normalizeDisplayScreenList(screenList, fallback = DISPLAY_SCREEN_KEYS, options = {}) {
@@ -1297,7 +1314,7 @@
 
     async function fetchWeddingRsvpSnapshot() {
       const client = getSupabaseClient();
-      if (!client) {
+      if (!client || !isRsvpDisplayScreenAvailable()) {
         return null;
       }
 

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.28";
+    const VERSION = "2.0.29";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -34,7 +34,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.27";
+    const VERSION = "2.0.28";
     const rotationIntervalMs = 30000;
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.28";
+const CACHE_NAME = "homeboard-v2.0.29";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.26";
+const CACHE_NAME = "homeboard-v2.0.27";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.27";
+const CACHE_NAME = "homeboard-v2.0.28";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.29";
+const CACHE_NAME = "homeboard-v2.0.30";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary
- hardcode RSVP availability to household `a1b2c3d4-e5f6-7890-abcd-ef1234567890`
- hide the RSVP admin tab and block navigation for every other household
- prevent non-wedding households from rendering the RSVP display screen or fetching RSVP data
- bump the shipped app version to `2.0.27` and align the service worker cache key

## Why
RSVP is a one-household wedding feature, but it was still visible across other households in both admin and display mode. That exposed an irrelevant screen and allowed unnecessary RSVP data loading outside the intended household.

## User impact
- the wedding household keeps the RSVP experience as-is
- every other household no longer sees RSVP in admin or display
- non-wedding households no longer fetch RSVP snapshot data at all

## Root cause
The existing RSVP availability logic only considered the retirement date. It did not enforce the required household ID gate before admin navigation, display rendering, or RSVP snapshot fetches.

## Validation
- `node --check js/shared.js`
- `node --check js/admin-core.js`
- `node --check js/admin-rsvp.js`

AI-assisted: Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RSVP feature availability is now controlled at the household level.
  * Admin interface dynamically shows or hides RSVP options based on household availability.

* **Improvements**
  * Admin navigation layout redesigned for better responsiveness and consistency.
  * Service worker and application cache updated to version 2.0.30.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisaug21/homeboard/pull/65)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->