### PR TITLE
Add GA4 global site tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#F5F0E8">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-CCSFWZBLDH"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-CCSFWZBLDH');
+  </script>
   <title>Homeboard</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- add the standard GA4 `gtag.js` async snippet to the `index.html` `<head>`
- configure the measurement ID `G-CCSFWZBLDH`
- leave CSS, JS behavior, content, and routing unchanged

## Validation
- reviewed the git diff to confirm only the `<head>` section of `index.html` changed
- confirmed the worktree change set stayed scoped to `index.html` for this commit

AI-assisted: Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled analytics tracking to gather insights into app usage patterns and performance metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisaug21/homeboard/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->