### PR TITLE
Add marketing homepage and display route

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Homeboard is a household command-center PWA built for two surfaces:
 
-- a wall-mounted display at `/` that rotates through shared household info
+- a marketing landing page at `/`
+- a wall-mounted display at `/display` that rotates through shared household info
 - a phone-friendly admin app at `/admin` for managing that household
 - a public self-serve signup page at `/signup` for new household creation with invite codes
 
@@ -27,11 +28,12 @@ Both modes are served from a single `index.html`.
 
 | Mode | URL | Intended device | Orientation |
 |---|---|---|---|
-| Display | `/` | wall tablet | landscape |
+| Marketing | `/` | desktop or phone | responsive |
+| Display | `/display` | wall tablet | landscape |
 | Admin | `/admin` | phone | portrait |
 | Signup | `/signup` | phone | portrait |
 
-Netlify rewrites `/admin` to `index.html` and `/signup` to `signup.html`. The main app decides which mode to boot from `window.location.pathname` before the main scripts run.
+Netlify rewrites `/display` and `/admin` to `index.html` and rewrites `/signup` to `signup.html`. The main app decides which mode to boot from `window.location.pathname` before the main scripts run.
 
 ## Auth And Access
 

--- a/index.html
+++ b/index.html
@@ -18,17 +18,23 @@
   <script>
     (function() {
       var pathname = window.location.pathname.replace(/\/+$/, "") || "/";
-      var mode = pathname === "/admin" ? "admin" : "display";
-      // Auto-redirect mobile screens to admin view
-      if (mode !== "admin" && window.innerWidth <= 768) {
+      var mode = pathname === "/admin"
+        ? "admin"
+        : pathname === "/display"
+          ? "display"
+          : "marketing";
+      // Auto-redirect small screens only from the display route
+      if (mode === "display" && window.innerWidth <= 768) {
         window.location.replace("/admin");
         return;
       }
       document.documentElement.setAttribute("data-mode", mode);
-      var manifestLink = document.createElement("link");
-      manifestLink.rel = "manifest";
-      manifestLink.href = mode === "admin" ? "/manifest-admin.json" : "/manifest.json";
-      document.head.appendChild(manifestLink);
+      if (mode === "admin" || mode === "display") {
+        var manifestLink = document.createElement("link");
+        manifestLink.rel = "manifest";
+        manifestLink.href = mode === "admin" ? "/manifest-admin.json" : "/manifest.json";
+        document.head.appendChild(manifestLink);
+      }
       if (mode === "admin") {
         document.querySelector('meta[name="theme-color"]').setAttribute("content", "#B45309");
         var s = document.createElement("style");
@@ -119,12 +125,698 @@
       display: none !important;
     }
 
+    html[data-mode="marketing"] #display-app,
+    html[data-mode="marketing"] #admin-app,
+    html[data-mode="display"] #marketing-app,
+    html[data-mode="admin"] #marketing-app {
+      display: none !important;
+    }
+
+    html[data-mode="marketing"],
+    html[data-mode="marketing"] body {
+      min-height: 100%;
+      height: auto;
+      overflow: auto;
+    }
+
+    .marketing-shell {
+      --marketing-bg: #F5F0E8;
+      --marketing-surface: #FFFDF7;
+      --marketing-text: #1C1917;
+      --marketing-accent: #B45309;
+      --marketing-accent-soft: rgba(180, 83, 9, 0.12);
+      --marketing-secondary: #15803D;
+      --marketing-secondary-soft: rgba(21, 128, 61, 0.12);
+      --marketing-muted: #78716C;
+      --marketing-border: rgba(28, 25, 23, 0.10);
+      --marketing-shadow: 0 24px 60px rgba(28, 25, 23, 0.08);
+      position: relative;
+      min-height: 100dvh;
+      padding: 32px 20px 40px;
+      color: var(--marketing-text);
+      background:
+        radial-gradient(circle at top left, rgba(180, 83, 9, 0.16), transparent 30%),
+        radial-gradient(circle at top right, rgba(21, 128, 61, 0.12), transparent 28%),
+        linear-gradient(180deg, #fbf7ef 0%, var(--marketing-bg) 42%, #f1ebdf 100%);
+    }
+
+    .marketing-shell::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background-image:
+        linear-gradient(rgba(28, 25, 23, 0.02) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(28, 25, 23, 0.02) 1px, transparent 1px);
+      background-size: 24px 24px;
+      pointer-events: none;
+      mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.18), transparent 78%);
+    }
+
+    .marketing-layout {
+      position: relative;
+      z-index: 1;
+      max-width: 1160px;
+      margin: 0 auto;
+      display: grid;
+      gap: 40px;
+    }
+
+    .marketing-hero {
+      display: grid;
+      gap: 28px;
+      padding-top: 12px;
+    }
+
+    .marketing-brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 14px;
+      width: fit-content;
+      padding: 12px 16px;
+      background: rgba(255, 253, 247, 0.72);
+      border: 1px solid rgba(28, 25, 23, 0.08);
+      border-radius: 999px;
+      box-shadow: 0 10px 24px rgba(28, 25, 23, 0.05);
+      backdrop-filter: blur(10px);
+    }
+
+    .marketing-brand img {
+      display: block;
+      width: 144px;
+      max-width: 100%;
+      height: auto;
+    }
+
+    .marketing-hero-copy {
+      display: grid;
+      gap: 16px;
+      max-width: 760px;
+    }
+
+    .marketing-kicker {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      width: fit-content;
+      padding: 8px 12px;
+      border-radius: 999px;
+      background: var(--marketing-accent-soft);
+      color: var(--marketing-accent);
+      font-size: 0.88rem;
+      font-weight: 800;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .marketing-kicker i {
+      width: 16px;
+      height: 16px;
+    }
+
+    .marketing-hero-copy h1 {
+      margin: 0;
+      font-family: "Bricolage Grotesque", "Manrope", sans-serif;
+      font-size: clamp(2.6rem, 5.6vw, 5rem);
+      line-height: 0.95;
+      letter-spacing: -0.05em;
+      color: var(--marketing-text);
+      max-width: 10ch;
+    }
+
+    .marketing-hero-copy p {
+      margin: 0;
+      max-width: 58ch;
+      color: var(--marketing-muted);
+      font-size: clamp(1rem, 2.2vw, 1.18rem);
+      line-height: 1.65;
+    }
+
+    .marketing-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 14px;
+    }
+
+    .marketing-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      min-height: 52px;
+      padding: 0 22px;
+      border-radius: 14px;
+      border: 1px solid transparent;
+      color: var(--marketing-text);
+      font-weight: 800;
+      text-decoration: none;
+      transition: transform 160ms ease, box-shadow 160ms ease, background-color 160ms ease, border-color 160ms ease;
+    }
+
+    .marketing-button:hover,
+    .marketing-button:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 14px 26px rgba(28, 25, 23, 0.10);
+    }
+
+    .marketing-button:focus-visible {
+      outline: 3px solid rgba(28, 25, 23, 0.20);
+      outline-offset: 3px;
+    }
+
+    .marketing-button--primary {
+      background: var(--marketing-accent);
+      color: #FFFDF7;
+    }
+
+    .marketing-button--secondary {
+      background: rgba(255, 253, 247, 0.72);
+      border-color: rgba(28, 25, 23, 0.12);
+      color: var(--marketing-text);
+    }
+
+    .marketing-widgets {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 20px;
+    }
+
+    .marketing-card {
+      position: relative;
+      display: grid;
+      gap: 18px;
+      min-height: 280px;
+      padding: 22px;
+      background: var(--marketing-surface);
+      border: 1px solid var(--marketing-border);
+      border-radius: 24px;
+      box-shadow: var(--marketing-shadow);
+      overflow: hidden;
+      opacity: 0;
+      transform: translateY(26px);
+      animation: marketing-card-enter 700ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+    }
+
+    .marketing-card:nth-child(2) {
+      animation-delay: 110ms;
+    }
+
+    .marketing-card:nth-child(3) {
+      animation-delay: 220ms;
+    }
+
+    .marketing-card::after {
+      content: "";
+      position: absolute;
+      inset: auto -24px -42px auto;
+      width: 132px;
+      height: 132px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(180, 83, 9, 0.16), transparent 70%);
+      pointer-events: none;
+    }
+
+    .marketing-card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .marketing-card-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 0.95rem;
+      font-weight: 800;
+      letter-spacing: 0.01em;
+    }
+
+    .marketing-card-label i {
+      width: 18px;
+      height: 18px;
+      color: var(--marketing-accent);
+    }
+
+    .marketing-card-badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 34px;
+      min-height: 34px;
+      padding: 0 10px;
+      border-radius: 999px;
+      background: rgba(245, 240, 232, 0.92);
+      color: var(--marketing-muted);
+      font-size: 0.78rem;
+      font-weight: 800;
+      border: 1px solid rgba(28, 25, 23, 0.08);
+    }
+
+    .marketing-calendar {
+      display: grid;
+      gap: 14px;
+      align-content: start;
+    }
+
+    .marketing-calendar-weekdays,
+    .marketing-calendar-days {
+      display: grid;
+      grid-template-columns: repeat(7, minmax(0, 1fr));
+      gap: 8px;
+    }
+
+    .marketing-calendar-weekdays span {
+      color: var(--marketing-muted);
+      font-size: 0.78rem;
+      font-weight: 800;
+      text-align: center;
+    }
+
+    .marketing-calendar-day {
+      display: grid;
+      gap: 8px;
+      align-content: start;
+      min-height: 84px;
+      padding: 10px 8px;
+      border-radius: 18px;
+      background: #F8F3EA;
+      border: 1px solid rgba(28, 25, 23, 0.06);
+    }
+
+    .marketing-calendar-day strong {
+      font-size: 0.92rem;
+      font-weight: 800;
+      text-align: center;
+    }
+
+    .marketing-pill {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      min-height: 22px;
+      padding: 0 8px;
+      border-radius: 999px;
+      font-size: 0.72rem;
+      font-weight: 700;
+      white-space: nowrap;
+    }
+
+    .marketing-pill--amber {
+      background: rgba(180, 83, 9, 0.14);
+      color: var(--marketing-accent);
+    }
+
+    .marketing-pill--green {
+      background: rgba(21, 128, 61, 0.14);
+      color: var(--marketing-secondary);
+    }
+
+    .marketing-pill--ink {
+      background: rgba(28, 25, 23, 0.08);
+      color: var(--marketing-text);
+    }
+
+    .marketing-todos {
+      display: grid;
+      gap: 14px;
+      align-content: start;
+    }
+
+    .marketing-todo-row {
+      display: grid;
+      grid-template-columns: 22px minmax(0, 1fr);
+      align-items: center;
+      gap: 12px;
+      padding: 14px 16px;
+      border-radius: 18px;
+      background: #F8F3EA;
+      border: 1px solid rgba(28, 25, 23, 0.06);
+    }
+
+    .marketing-todo-check {
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      border: 2px solid rgba(180, 83, 9, 0.42);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--marketing-surface);
+      background: transparent;
+      font-size: 0.78rem;
+      font-weight: 900;
+    }
+
+    .marketing-todo-row.is-done .marketing-todo-check {
+      background: var(--marketing-accent);
+      border-color: var(--marketing-accent);
+      color: #FFFDF7;
+    }
+
+    .marketing-todo-copy {
+      display: grid;
+      gap: 4px;
+    }
+
+    .marketing-todo-copy strong {
+      font-size: 0.97rem;
+    }
+
+    .marketing-todo-copy span {
+      color: var(--marketing-muted);
+      font-size: 0.82rem;
+    }
+
+    .marketing-todo-row.is-done .marketing-todo-copy strong,
+    .marketing-todo-row.is-done .marketing-todo-copy span {
+      color: rgba(120, 113, 108, 0.86);
+      text-decoration: line-through;
+      text-decoration-thickness: 1.5px;
+    }
+
+    .marketing-countdown {
+      display: grid;
+      place-items: center;
+      align-content: center;
+      gap: 14px;
+      min-height: 100%;
+      text-align: center;
+      padding: 8px 0;
+    }
+
+    .marketing-countdown-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border-radius: 999px;
+      background: var(--marketing-secondary-soft);
+      color: var(--marketing-secondary);
+      font-size: 0.84rem;
+      font-weight: 800;
+    }
+
+    .marketing-countdown-title {
+      font-family: "Fraunces", serif;
+      font-size: clamp(1.4rem, 3vw, 1.8rem);
+      line-height: 1.15;
+    }
+
+    .marketing-countdown-number {
+      font-family: "Bricolage Grotesque", "Manrope", sans-serif;
+      font-size: clamp(4.2rem, 10vw, 5.8rem);
+      line-height: 0.9;
+      letter-spacing: -0.05em;
+      color: var(--marketing-accent);
+    }
+
+    .marketing-countdown-caption {
+      color: var(--marketing-muted);
+      font-size: 0.94rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      font-weight: 800;
+    }
+
+    .marketing-features {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 16px;
+    }
+
+    .marketing-feature {
+      display: grid;
+      gap: 10px;
+      padding: 20px 22px;
+      background: rgba(255, 253, 247, 0.70);
+      border: 1px solid rgba(28, 25, 23, 0.08);
+      border-radius: 20px;
+    }
+
+    .marketing-feature-icon {
+      width: 42px;
+      height: 42px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 14px;
+      background: rgba(180, 83, 9, 0.12);
+      color: var(--marketing-accent);
+    }
+
+    .marketing-feature-icon i {
+      width: 20px;
+      height: 20px;
+    }
+
+    .marketing-feature h2 {
+      margin: 0;
+      font-size: 1.02rem;
+      line-height: 1.2;
+    }
+
+    .marketing-feature p {
+      margin: 0;
+      color: var(--marketing-muted);
+      line-height: 1.55;
+      font-size: 0.94rem;
+    }
+
+    .marketing-footer {
+      color: var(--marketing-muted);
+      font-size: 0.9rem;
+      text-align: center;
+      padding: 4px 0 0;
+    }
+
+    .marketing-footer a {
+      color: var(--marketing-accent);
+      font-weight: 800;
+      text-decoration: none;
+    }
+
+    .marketing-footer a:hover,
+    .marketing-footer a:focus-visible {
+      text-decoration: underline;
+    }
+
+    @keyframes marketing-card-enter {
+      from {
+        opacity: 0;
+        transform: translateY(26px);
+      }
+
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    @media (max-width: 980px) {
+      .marketing-widgets,
+      .marketing-features {
+        grid-template-columns: 1fr;
+      }
+
+      .marketing-card {
+        min-height: 0;
+      }
+    }
+
+    @media (max-width: 720px) {
+      .marketing-shell {
+        padding: 24px 16px 32px;
+      }
+
+      .marketing-hero-copy h1 {
+        max-width: none;
+      }
+
+      .marketing-actions {
+        display: grid;
+      }
+
+      .marketing-button {
+        width: 100%;
+      }
+
+      .marketing-calendar-day {
+        min-height: 72px;
+        padding: 9px 6px;
+      }
+
+      .marketing-pill {
+        min-height: 18px;
+        padding: 0 6px;
+        font-size: 0.64rem;
+      }
+    }
+
   </style>
   <link rel="stylesheet" href="css/display.css?v=2.0.0">
   <link rel="stylesheet" href="css/admin.css?v=2.0.0">
   <link rel="stylesheet" href="js/vendor/cropper.min.css">
 </head>
 <body>
+  <main class="marketing-shell" id="marketing-app">
+    <div class="marketing-layout">
+      <section class="marketing-hero" aria-labelledby="marketing-title">
+        <div class="marketing-brand" aria-label="Homeboard">
+          <img src="homeboard_logo.svg" alt="Homeboard" width="144" decoding="async">
+        </div>
+        <div class="marketing-hero-copy">
+          <div class="marketing-kicker">
+            <i data-lucide="monitor-smartphone"></i>
+            Homeboard
+          </div>
+          <h1 id="marketing-title">A smart dashboard for your home, built for the kitchen wall.</h1>
+          <p>Calendar, to-dos, meal plan, and countdowns — all on a tablet mounted where your family actually gathers.</p>
+          <div class="marketing-actions">
+            <a class="marketing-button marketing-button--primary" href="/signup">Get started</a>
+            <a class="marketing-button marketing-button--secondary" href="/admin">Already have an account?</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="marketing-widgets" aria-label="Homeboard features preview">
+        <article class="marketing-card">
+          <div class="marketing-card-header">
+            <div class="marketing-card-label">
+              <i data-lucide="calendar-days"></i>
+              <span>Calendar</span>
+            </div>
+            <span class="marketing-card-badge">Week</span>
+          </div>
+          <div class="marketing-calendar">
+            <div class="marketing-calendar-weekdays">
+              <span>Mon</span>
+              <span>Tue</span>
+              <span>Wed</span>
+              <span>Thu</span>
+              <span>Fri</span>
+              <span>Sat</span>
+              <span>Sun</span>
+            </div>
+            <div class="marketing-calendar-days">
+              <div class="marketing-calendar-day">
+                <strong>12</strong>
+                <span class="marketing-pill marketing-pill--amber">Piano</span>
+              </div>
+              <div class="marketing-calendar-day">
+                <strong>13</strong>
+              </div>
+              <div class="marketing-calendar-day">
+                <strong>14</strong>
+                <span class="marketing-pill marketing-pill--green">Dinner</span>
+              </div>
+              <div class="marketing-calendar-day">
+                <strong>15</strong>
+              </div>
+              <div class="marketing-calendar-day">
+                <strong>16</strong>
+                <span class="marketing-pill marketing-pill--ink">Game Night</span>
+              </div>
+              <div class="marketing-calendar-day">
+                <strong>17</strong>
+              </div>
+              <div class="marketing-calendar-day">
+                <strong>18</strong>
+              </div>
+            </div>
+          </div>
+        </article>
+
+        <article class="marketing-card">
+          <div class="marketing-card-header">
+            <div class="marketing-card-label">
+              <i data-lucide="list-todo"></i>
+              <span>To-dos</span>
+            </div>
+            <span class="marketing-card-badge">Today</span>
+          </div>
+          <div class="marketing-todos">
+            <div class="marketing-todo-row">
+              <span class="marketing-todo-check" aria-hidden="true"></span>
+              <div class="marketing-todo-copy">
+                <strong>Pack soccer snacks</strong>
+                <span>Assigned to Chris</span>
+              </div>
+            </div>
+            <div class="marketing-todo-row is-done">
+              <span class="marketing-todo-check" aria-hidden="true">✓</span>
+              <div class="marketing-todo-copy">
+                <strong>Start dishwasher</strong>
+                <span>Completed this morning</span>
+              </div>
+            </div>
+            <div class="marketing-todo-row">
+              <span class="marketing-todo-check" aria-hidden="true"></span>
+              <div class="marketing-todo-copy">
+                <strong>Order birthday balloons</strong>
+                <span>Due Friday</span>
+              </div>
+            </div>
+            <div class="marketing-todo-row">
+              <span class="marketing-todo-check" aria-hidden="true"></span>
+              <div class="marketing-todo-copy">
+                <strong>Defrost taco meat</strong>
+                <span>Meal prep reminder</span>
+              </div>
+            </div>
+          </div>
+        </article>
+
+        <article class="marketing-card">
+          <div class="marketing-card-header">
+            <div class="marketing-card-label">
+              <i data-lucide="timer-reset"></i>
+              <span>Countdowns</span>
+            </div>
+            <span class="marketing-card-badge">Live</span>
+          </div>
+          <div class="marketing-countdown">
+            <div class="marketing-countdown-badge">
+              <i data-lucide="sparkles"></i>
+              Looking forward
+            </div>
+            <div class="marketing-countdown-title">Bailey &amp; Chris 🎉</div>
+            <div class="marketing-countdown-number">147</div>
+            <div class="marketing-countdown-caption">days</div>
+          </div>
+        </article>
+      </section>
+
+      <section class="marketing-features" aria-label="Why families use Homeboard">
+        <article class="marketing-feature">
+          <div class="marketing-feature-icon">
+            <i data-lucide="calendar-days"></i>
+          </div>
+          <h2>Always up to date</h2>
+          <p>Syncs with Google Calendar automatically.</p>
+        </article>
+        <article class="marketing-feature">
+          <div class="marketing-feature-icon">
+            <i data-lucide="users"></i>
+          </div>
+          <h2>Built for households</h2>
+          <p>Multiple members, shared to-dos, meal planning.</p>
+        </article>
+        <article class="marketing-feature">
+          <div class="marketing-feature-icon">
+            <i data-lucide="timer"></i>
+          </div>
+          <h2>Count down together</h2>
+          <p>See what&apos;s coming up as a family.</p>
+        </article>
+      </section>
+
+      <footer class="marketing-footer">
+        Already set up your display? Go to <a href="/display">/display</a> on your tablet.
+      </footer>
+    </div>
+  </main>
+
   <div class="app-shell" id="display-app">
     <section class="display-pairing" id="display-pairing-screen" hidden aria-labelledby="display-pairing-title">
       <div class="display-pairing-card">

--- a/index.html
+++ b/index.html
@@ -348,6 +348,7 @@
     }
 
     .marketing-card-preview--todos {
+      height: 244px;
       padding-block: 12px;
     }
 

--- a/index.html
+++ b/index.html
@@ -434,6 +434,7 @@
       width: 100%;
       display: grid;
       gap: 10px;
+      min-height: 196px;
       padding: 12px;
       border-radius: 18px;
       border: 1px solid rgba(28, 25, 23, 0.08);

--- a/index.html
+++ b/index.html
@@ -282,13 +282,14 @@
     .marketing-features-grid {
       display: grid;
       grid-template-columns: repeat(4, minmax(0, 1fr));
-      gap: 20px;
+      gap: 24px;
+      margin-bottom: 18px;
     }
 
     .marketing-card {
       display: flex;
       flex-direction: column;
-      gap: 18px;
+      gap: 22px;
       min-height: 340px;
       padding: 22px;
       background: var(--marketing-surface);
@@ -317,7 +318,7 @@
       display: flex;
       flex-direction: column;
       align-items: flex-start;
-      gap: 16px;
+      gap: 20px;
       flex: 1 1 auto;
     }
 
@@ -338,7 +339,7 @@
 
     .marketing-card-preview {
       width: 100%;
-      height: 160px;
+      height: 220px;
       flex: 1 1 auto;
       display: flex;
       align-items: center;
@@ -543,13 +544,14 @@
 
     .marketing-countdown-title {
       font-family: "Fraunces", serif;
-      font-size: clamp(1.05rem, 1.5vw, 1.35rem);
+      font-size: clamp(0.92rem, 1.2vw, 1.1rem);
       line-height: 1.1;
+      white-space: nowrap;
     }
 
     .marketing-countdown-number {
       font-family: "Bricolage Grotesque", "Manrope", sans-serif;
-      font-size: clamp(3.1rem, 5.4vw, 4.1rem);
+      font-size: clamp(2.7rem, 4.6vw, 3.5rem);
       line-height: 0.9;
       letter-spacing: -0.05em;
       color: var(--marketing-accent);

--- a/index.html
+++ b/index.html
@@ -274,30 +274,28 @@
 
     .marketing-button--secondary {
       background: rgba(255, 253, 247, 0.72);
-      border-color: rgba(120, 113, 108, 0.42);
+      border-color: rgba(120, 113, 108, 0.40);
       border-width: 2px;
       color: var(--marketing-text);
     }
 
-    .marketing-widgets {
-      position: relative;
+    .marketing-features-grid {
       display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-template-columns: repeat(4, minmax(0, 1fr));
       gap: 20px;
-      align-items: start;
     }
 
     .marketing-card {
-      display: grid;
+      display: flex;
+      flex-direction: column;
       gap: 18px;
-      min-height: 280px;
+      min-height: 340px;
       padding: 22px;
       background: var(--marketing-surface);
       border: 1px solid var(--marketing-border);
       border-radius: 24px;
       box-shadow: var(--marketing-shadow);
-      align-content: start;
-      align-items: start;
+      align-items: stretch;
       opacity: 0;
       transform: translateY(26px);
       animation: marketing-card-enter 700ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
@@ -311,11 +309,16 @@
       animation-delay: 220ms;
     }
 
+    .marketing-card:nth-child(4) {
+      animation-delay: 330ms;
+    }
+
     .marketing-card-header {
       display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 12px;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 16px;
+      flex: 1 1 auto;
     }
 
     .marketing-card-label {
@@ -333,31 +336,47 @@
       color: var(--marketing-accent);
     }
 
-    .marketing-card-badge {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-width: 34px;
-      min-height: 34px;
-      padding: 0 10px;
-      border-radius: 999px;
-      background: rgba(245, 240, 232, 0.92);
+    .marketing-card-preview {
+      width: 100%;
+      flex: 1 1 auto;
+      display: flex;
+      align-items: stretch;
+    }
+
+    .marketing-card-copy {
+      display: grid;
+      gap: 8px;
+    }
+
+    .marketing-card-copy h2 {
+      margin: 0;
+      font-size: 1.08rem;
+      line-height: 1.2;
+      color: var(--marketing-text);
+    }
+
+    .marketing-card-copy p {
+      margin: 0;
       color: var(--marketing-muted);
-      font-size: 0.78rem;
-      font-weight: 800;
-      border: 1px solid rgba(28, 25, 23, 0.08);
+      font-size: 0.94rem;
+      line-height: 1.6;
     }
 
     .marketing-calendar {
-      display: grid;
-      gap: 14px;
-      align-content: start;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      padding: 16px;
+      border-radius: 20px;
+      border: 1px solid rgba(28, 25, 23, 0.08);
+      background: #F8F3EA;
     }
 
     .marketing-calendar-weekdays,
     .marketing-calendar-days {
       display: grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 8px;
     }
 
@@ -370,12 +389,12 @@
 
     .marketing-calendar-day {
       display: grid;
-      gap: 8px;
+      gap: 6px;
       align-content: start;
-      min-height: 84px;
+      min-height: 58px;
       padding: 10px 8px;
-      border-radius: 18px;
-      background: #F8F3EA;
+      border-radius: 14px;
+      background: rgba(255, 253, 247, 0.84);
       border: 1px solid rgba(28, 25, 23, 0.06);
     }
 
@@ -390,10 +409,10 @@
       align-items: center;
       justify-content: center;
       width: 100%;
-      min-height: 22px;
-      padding: 0 8px;
+      min-height: 20px;
+      padding: 0 6px;
       border-radius: 999px;
-      font-size: 0.72rem;
+      font-size: 0.68rem;
       font-weight: 700;
       white-space: nowrap;
     }
@@ -414,9 +433,13 @@
     }
 
     .marketing-todos {
+      width: 100%;
       display: grid;
-      gap: 14px;
-      align-content: start;
+      gap: 10px;
+      padding: 16px;
+      border-radius: 20px;
+      border: 1px solid rgba(28, 25, 23, 0.08);
+      background: #F8F3EA;
     }
 
     .marketing-todo-row {
@@ -424,9 +447,9 @@
       grid-template-columns: 22px minmax(0, 1fr);
       align-items: center;
       gap: 12px;
-      padding: 14px 16px;
-      border-radius: 18px;
-      background: #F8F3EA;
+      padding: 12px 14px;
+      border-radius: 14px;
+      background: rgba(255, 253, 247, 0.84);
       border: 1px solid rgba(28, 25, 23, 0.06);
     }
 
@@ -451,44 +474,88 @@
     }
 
     .marketing-todo-copy {
-      display: grid;
-      gap: 4px;
+      min-width: 0;
     }
 
     .marketing-todo-copy strong {
       font-size: 0.97rem;
+      line-height: 1.3;
     }
 
-    .marketing-todo-copy span {
-      color: var(--marketing-muted);
-      font-size: 0.82rem;
-    }
-
-    .marketing-todo-row.is-done .marketing-todo-copy strong,
-    .marketing-todo-row.is-done .marketing-todo-copy span {
+    .marketing-todo-row.is-done .marketing-todo-copy strong {
       color: rgba(120, 113, 108, 0.86);
       text-decoration: line-through;
       text-decoration-thickness: 1.5px;
     }
 
-    .marketing-countdown {
+    .marketing-meals {
+      width: 100%;
       display: grid;
-      align-content: center;
-      gap: 14px;
+      gap: 0;
+      padding: 16px;
+      border-radius: 20px;
+      border: 1px solid rgba(28, 25, 23, 0.08);
+      background: #F8F3EA;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      overflow: hidden;
+    }
+
+    .marketing-meal-cell {
+      min-width: 0;
+      display: grid;
+      gap: 8px;
+      padding: 12px 10px;
+      background: rgba(255, 253, 247, 0.84);
+      border-top: 1px solid rgba(28, 25, 23, 0.08);
+      border-right: 1px solid rgba(28, 25, 23, 0.08);
+    }
+
+    .marketing-meal-cell:nth-child(-n + 3) {
+      border-top: 0;
+    }
+
+    .marketing-meal-cell:nth-child(3n) {
+      border-right: 0;
+    }
+
+    .marketing-meal-day {
+      color: var(--marketing-muted);
+      font-size: 0.78rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .marketing-meal-name {
+      font-size: 0.95rem;
+      line-height: 1.35;
+      color: var(--marketing-text);
+    }
+
+    .marketing-countdown {
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      gap: 12px;
       min-height: 100%;
       text-align: center;
-      padding: 8px 0;
+      padding: 18px 16px;
+      border-radius: 20px;
+      border: 1px solid rgba(28, 25, 23, 0.08);
+      background: #F8F3EA;
     }
 
     .marketing-countdown-title {
       font-family: "Fraunces", serif;
-      font-size: clamp(1.4rem, 3vw, 1.8rem);
+      font-size: clamp(1.3rem, 2vw, 1.65rem);
       line-height: 1.15;
     }
 
     .marketing-countdown-number {
       font-family: "Bricolage Grotesque", "Manrope", sans-serif;
-      font-size: clamp(4.2rem, 10vw, 5.8rem);
+      font-size: clamp(4rem, 7vw, 5.2rem);
       line-height: 0.9;
       letter-spacing: -0.05em;
       color: var(--marketing-accent);
@@ -496,77 +563,39 @@
 
     .marketing-countdown-caption {
       color: var(--marketing-text);
-      font-size: 0.94rem;
+      font-size: 0.9rem;
       letter-spacing: 0.12em;
       text-transform: uppercase;
       font-weight: 800;
     }
 
-    .marketing-features {
-      position: relative;
-      display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 16px;
-      padding-top: 30px;
-    }
-
-    .marketing-features::before {
-      content: "";
-      position: absolute;
-      top: 0;
-      left: 50%;
-      transform: translateX(-50%);
-      width: min(100%, 980px);
-      height: 1px;
-      background: linear-gradient(90deg, transparent, rgba(120, 113, 108, 0.28), transparent);
-    }
-
-    .marketing-features::after {
-      content: "";
-      position: absolute;
-      inset: 8px -18px -16px;
-      border-radius: 28px;
-      background: rgba(255, 253, 247, 0.30);
-      border: 1px solid rgba(28, 25, 23, 0.04);
-      z-index: -1;
-    }
-
-    .marketing-feature {
-      display: grid;
-      gap: 10px;
-      padding: 20px 22px;
-      background: rgba(255, 253, 247, 0.70);
-      border: 1px solid rgba(28, 25, 23, 0.08);
-      border-radius: 20px;
-    }
-
-    .marketing-feature-icon {
-      width: 42px;
-      height: 42px;
-      display: inline-flex;
+    .marketing-cta-band {
+      display: flex;
       align-items: center;
-      justify-content: center;
-      border-radius: 14px;
-      background: rgba(180, 83, 9, 0.12);
+      justify-content: space-between;
+      gap: 24px;
+      padding: 48px 32px;
+      border-radius: 28px;
+      background: var(--marketing-accent);
+      box-shadow: 0 24px 44px rgba(180, 83, 9, 0.24);
+    }
+
+    .marketing-cta-copy {
+      max-width: 620px;
+      color: #FFFDF7;
+      font-family: "Bricolage Grotesque", "Manrope", sans-serif;
+      font-size: clamp(1.6rem, 3vw, 2.3rem);
+      line-height: 1.08;
+      letter-spacing: -0.04em;
+      font-weight: 700;
+    }
+
+    .marketing-button--inverse {
+      flex: 0 0 auto;
+      background: #FFFDF7;
       color: var(--marketing-accent);
-    }
-
-    .marketing-feature-icon i {
-      width: 20px;
-      height: 20px;
-    }
-
-    .marketing-feature h2 {
-      margin: 0;
-      font-size: 1.02rem;
-      line-height: 1.2;
-    }
-
-    .marketing-feature p {
-      margin: 0;
-      color: var(--marketing-muted);
-      line-height: 1.55;
-      font-size: 0.94rem;
+      border-color: #FFFDF7;
+      min-width: 164px;
     }
 
     .marketing-footer {
@@ -600,18 +629,17 @@
       }
     }
 
-    @media (max-width: 980px) {
-      .marketing-widgets,
-      .marketing-features {
-        grid-template-columns: 1fr;
+    @media (max-width: 900px) {
+      .marketing-features-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
       }
 
-      .marketing-card {
-        min-height: 0;
+      .marketing-cta-band {
+        padding: 44px 28px;
       }
     }
 
-    @media (max-width: 720px) {
+    @media (max-width: 600px) {
       .marketing-shell {
         padding: 24px 16px 32px;
       }
@@ -628,19 +656,26 @@
         width: 100%;
       }
 
-      .marketing-calendar-day {
-        min-height: 72px;
-        padding: 9px 6px;
+      .marketing-features-grid {
+        grid-template-columns: 1fr;
       }
 
-      .marketing-pill {
-        min-height: 18px;
-        padding: 0 6px;
-        font-size: 0.64rem;
+      .marketing-card {
+        min-height: 0;
       }
 
-      .marketing-features {
-        padding-top: 24px;
+      .marketing-calendar-day,
+      .marketing-meal-cell,
+      .marketing-todo-row {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+
+      .marketing-cta-band {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 20px;
+        padding: 40px 22px;
       }
     }
 
@@ -666,37 +701,37 @@
         </div>
       </section>
 
-      <section class="marketing-widgets" aria-label="Homeboard features preview">
+      <section class="marketing-features-grid" aria-label="Homeboard features preview">
         <article class="marketing-card">
           <div class="marketing-card-header">
             <div class="marketing-card-label">
               <i data-lucide="calendar-days"></i>
-              <span>Calendar</span>
+            </div>
+            <div class="marketing-card-preview">
+              <div class="marketing-calendar">
+                <div class="marketing-calendar-weekdays">
+                  <span>Wed</span>
+                  <span>Thu</span>
+                  <span>Fri</span>
+                </div>
+                <div class="marketing-calendar-days">
+                  <div class="marketing-calendar-day">
+                    <strong>14</strong>
+                  </div>
+                  <div class="marketing-calendar-day">
+                    <strong>15</strong>
+                    <span class="marketing-pill marketing-pill--amber">Dinner</span>
+                  </div>
+                  <div class="marketing-calendar-day">
+                    <strong>16</strong>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
-          <div class="marketing-calendar">
-            <div class="marketing-calendar-weekdays">
-              <span>Wed</span>
-              <span>Thu</span>
-              <span>Fri</span>
-              <span>Sat</span>
-            </div>
-            <div class="marketing-calendar-days">
-              <div class="marketing-calendar-day">
-                <strong>14</strong>
-                <span class="marketing-pill marketing-pill--amber">Piano</span>
-              </div>
-              <div class="marketing-calendar-day">
-                <strong>15</strong>
-                <span class="marketing-pill marketing-pill--green">Dinner</span>
-              </div>
-              <div class="marketing-calendar-day">
-                <strong>16</strong>
-              </div>
-              <div class="marketing-calendar-day">
-                <strong>17</strong>
-              </div>
-            </div>
+          <div class="marketing-card-copy">
+            <h2>Calendar</h2>
+            <p>Syncs with Google Calendar so everyone sees what&apos;s coming up.</p>
           </div>
         </article>
 
@@ -704,39 +739,61 @@
           <div class="marketing-card-header">
             <div class="marketing-card-label">
               <i data-lucide="list-todo"></i>
-              <span>To-dos</span>
             </div>
-            <span class="marketing-card-badge">Today</span>
+            <div class="marketing-card-preview">
+              <div class="marketing-todos">
+                <div class="marketing-todo-row">
+                  <span class="marketing-todo-check" aria-hidden="true"></span>
+                  <div class="marketing-todo-copy">
+                    <strong>Pack soccer snacks</strong>
+                  </div>
+                </div>
+                <div class="marketing-todo-row is-done">
+                  <span class="marketing-todo-check" aria-hidden="true">✓</span>
+                  <div class="marketing-todo-copy">
+                    <strong>Start dishwasher</strong>
+                  </div>
+                </div>
+                <div class="marketing-todo-row">
+                  <span class="marketing-todo-check" aria-hidden="true"></span>
+                  <div class="marketing-todo-copy">
+                    <strong>Order birthday balloons</strong>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-          <div class="marketing-todos">
-            <div class="marketing-todo-row">
-              <span class="marketing-todo-check" aria-hidden="true"></span>
-              <div class="marketing-todo-copy">
-                <strong>Pack soccer snacks</strong>
-                <span>Assigned to Chris</span>
+          <div class="marketing-card-copy">
+            <h2>To-dos</h2>
+            <p>Shared household list, visible on the wall and manageable from your phone.</p>
+          </div>
+        </article>
+
+        <article class="marketing-card">
+          <div class="marketing-card-header">
+            <div class="marketing-card-label">
+              <i data-lucide="utensils-crossed"></i>
+            </div>
+            <div class="marketing-card-preview">
+              <div class="marketing-meals">
+                <div class="marketing-meal-cell">
+                  <span class="marketing-meal-day">Mon</span>
+                  <span class="marketing-meal-name">Tacos</span>
+                </div>
+                <div class="marketing-meal-cell">
+                  <span class="marketing-meal-day">Tue</span>
+                  <span class="marketing-meal-name">Pasta</span>
+                </div>
+                <div class="marketing-meal-cell">
+                  <span class="marketing-meal-day">Wed</span>
+                  <span class="marketing-meal-name">Stir fry</span>
+                </div>
               </div>
             </div>
-            <div class="marketing-todo-row is-done">
-              <span class="marketing-todo-check" aria-hidden="true">✓</span>
-              <div class="marketing-todo-copy">
-                <strong>Start dishwasher</strong>
-                <span>Completed this morning</span>
-              </div>
-            </div>
-            <div class="marketing-todo-row">
-              <span class="marketing-todo-check" aria-hidden="true"></span>
-              <div class="marketing-todo-copy">
-                <strong>Order birthday balloons</strong>
-                <span>Due Friday</span>
-              </div>
-            </div>
-            <div class="marketing-todo-row">
-              <span class="marketing-todo-check" aria-hidden="true"></span>
-              <div class="marketing-todo-copy">
-                <strong>Defrost taco meat</strong>
-                <span>Meal prep reminder</span>
-              </div>
-            </div>
+          </div>
+          <div class="marketing-card-copy">
+            <h2>Meal plan</h2>
+            <p>Plot out the week&apos;s dinners so nobody has to ask what&apos;s for dinner.</p>
           </div>
         </article>
 
@@ -744,39 +801,25 @@
           <div class="marketing-card-header">
             <div class="marketing-card-label">
               <i data-lucide="timer-reset"></i>
-              <span>Countdowns</span>
+            </div>
+            <div class="marketing-card-preview">
+              <div class="marketing-countdown">
+                <div class="marketing-countdown-title">Summer Vacation 🌴</div>
+                <div class="marketing-countdown-number">38</div>
+                <div class="marketing-countdown-caption">DAYS</div>
+              </div>
             </div>
           </div>
-          <div class="marketing-countdown">
-            <div class="marketing-countdown-title">Summer Vacation 🌴</div>
-            <div class="marketing-countdown-number">38</div>
-            <div class="marketing-countdown-caption">DAYS</div>
+          <div class="marketing-card-copy">
+            <h2>Countdowns</h2>
+            <p>Add anything worth looking forward to. The whole family sees it.</p>
           </div>
         </article>
       </section>
 
-      <section class="marketing-features" aria-label="Why families use Homeboard">
-        <article class="marketing-feature">
-          <div class="marketing-feature-icon">
-            <i data-lucide="calendar-days"></i>
-          </div>
-          <h2>Always up to date</h2>
-          <p>Connect your Google Calendar once and it shows up automatically, always current.</p>
-        </article>
-        <article class="marketing-feature">
-          <div class="marketing-feature-icon">
-            <i data-lucide="users"></i>
-          </div>
-          <h2>Built for households</h2>
-          <p>Add family members, share to-dos, plan meals together, and keep everyone on the same page.</p>
-        </article>
-        <article class="marketing-feature">
-          <div class="marketing-feature-icon">
-            <i data-lucide="timer"></i>
-          </div>
-          <h2>Count down together</h2>
-          <p>Add vacations, birthdays, holidays — anything worth looking forward to, visible to the whole household.</p>
-        </article>
+      <section class="marketing-cta-band" aria-label="Get started with Homeboard">
+        <div class="marketing-cta-copy">Control everything from your phone. See it all on your wall.</div>
+        <a class="marketing-button marketing-button--inverse" href="/signup">Get started</a>
       </section>
 
       <footer class="marketing-footer">

--- a/index.html
+++ b/index.html
@@ -178,13 +178,15 @@
       max-width: 1160px;
       margin: 0 auto;
       display: grid;
-      gap: 40px;
+      gap: 28px;
     }
 
     .marketing-hero {
       display: grid;
-      gap: 28px;
+      gap: 18px;
       padding-top: 12px;
+      justify-items: center;
+      text-align: center;
     }
 
     .marketing-brand {
@@ -209,52 +211,34 @@
 
     .marketing-hero-copy {
       display: grid;
-      gap: 16px;
-      max-width: 760px;
-    }
-
-    .marketing-kicker {
-      display: inline-flex;
-      align-items: center;
-      gap: 10px;
-      width: fit-content;
-      padding: 8px 12px;
-      border-radius: 999px;
-      background: var(--marketing-accent-soft);
-      color: var(--marketing-accent);
-      font-size: 0.88rem;
-      font-weight: 800;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-    }
-
-    .marketing-kicker i {
-      width: 16px;
-      height: 16px;
+      gap: 14px;
+      max-width: 920px;
+      justify-items: center;
     }
 
     .marketing-hero-copy h1 {
       margin: 0;
       font-family: "Bricolage Grotesque", "Manrope", sans-serif;
-      font-size: clamp(2.6rem, 5.6vw, 5rem);
-      line-height: 0.95;
+      font-size: clamp(2.75rem, 4.2vw, 4.2rem);
+      line-height: 1.02;
       letter-spacing: -0.05em;
       color: var(--marketing-text);
-      max-width: 10ch;
+      max-width: 14ch;
     }
 
     .marketing-hero-copy p {
       margin: 0;
-      max-width: 58ch;
+      max-width: 64ch;
       color: var(--marketing-muted);
-      font-size: clamp(1rem, 2.2vw, 1.18rem);
-      line-height: 1.65;
+      font-size: clamp(1rem, 1.65vw, 1.15rem);
+      line-height: 1.6;
     }
 
     .marketing-actions {
       display: flex;
       flex-wrap: wrap;
       gap: 14px;
+      justify-content: center;
     }
 
     .marketing-button {
@@ -290,18 +274,20 @@
 
     .marketing-button--secondary {
       background: rgba(255, 253, 247, 0.72);
-      border-color: rgba(28, 25, 23, 0.12);
+      border-color: rgba(120, 113, 108, 0.42);
+      border-width: 2px;
       color: var(--marketing-text);
     }
 
     .marketing-widgets {
+      position: relative;
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 20px;
+      align-items: start;
     }
 
     .marketing-card {
-      position: relative;
       display: grid;
       gap: 18px;
       min-height: 280px;
@@ -310,7 +296,8 @@
       border: 1px solid var(--marketing-border);
       border-radius: 24px;
       box-shadow: var(--marketing-shadow);
-      overflow: hidden;
+      align-content: start;
+      align-items: start;
       opacity: 0;
       transform: translateY(26px);
       animation: marketing-card-enter 700ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
@@ -322,17 +309,6 @@
 
     .marketing-card:nth-child(3) {
       animation-delay: 220ms;
-    }
-
-    .marketing-card::after {
-      content: "";
-      position: absolute;
-      inset: auto -24px -42px auto;
-      width: 132px;
-      height: 132px;
-      border-radius: 50%;
-      background: radial-gradient(circle, rgba(180, 83, 9, 0.16), transparent 70%);
-      pointer-events: none;
     }
 
     .marketing-card-header {
@@ -381,7 +357,7 @@
     .marketing-calendar-weekdays,
     .marketing-calendar-days {
       display: grid;
-      grid-template-columns: repeat(7, minmax(0, 1fr));
+      grid-template-columns: repeat(4, minmax(0, 1fr));
       gap: 8px;
     }
 
@@ -497,24 +473,11 @@
 
     .marketing-countdown {
       display: grid;
-      place-items: center;
       align-content: center;
       gap: 14px;
       min-height: 100%;
       text-align: center;
       padding: 8px 0;
-    }
-
-    .marketing-countdown-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 10px;
-      padding: 10px 14px;
-      border-radius: 999px;
-      background: var(--marketing-secondary-soft);
-      color: var(--marketing-secondary);
-      font-size: 0.84rem;
-      font-weight: 800;
     }
 
     .marketing-countdown-title {
@@ -532,7 +495,7 @@
     }
 
     .marketing-countdown-caption {
-      color: var(--marketing-muted);
+      color: var(--marketing-text);
       font-size: 0.94rem;
       letter-spacing: 0.12em;
       text-transform: uppercase;
@@ -540,9 +503,32 @@
     }
 
     .marketing-features {
+      position: relative;
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 16px;
+      padding-top: 30px;
+    }
+
+    .marketing-features::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      width: min(100%, 980px);
+      height: 1px;
+      background: linear-gradient(90deg, transparent, rgba(120, 113, 108, 0.28), transparent);
+    }
+
+    .marketing-features::after {
+      content: "";
+      position: absolute;
+      inset: 8px -18px -16px;
+      border-radius: 28px;
+      background: rgba(255, 253, 247, 0.30);
+      border: 1px solid rgba(28, 25, 23, 0.04);
+      z-index: -1;
     }
 
     .marketing-feature {
@@ -585,9 +571,10 @@
 
     .marketing-footer {
       color: var(--marketing-muted);
-      font-size: 0.9rem;
+      font-size: 0.94rem;
+      opacity: 0.72;
       text-align: center;
-      padding: 4px 0 0;
+      padding: 10px 0 0;
     }
 
     .marketing-footer a {
@@ -651,6 +638,10 @@
         padding: 0 6px;
         font-size: 0.64rem;
       }
+
+      .marketing-features {
+        padding-top: 24px;
+      }
     }
 
   </style>
@@ -666,10 +657,6 @@
           <img src="homeboard_logo.svg" alt="Homeboard" width="144" decoding="async">
         </div>
         <div class="marketing-hero-copy">
-          <div class="marketing-kicker">
-            <i data-lucide="monitor-smartphone"></i>
-            Homeboard
-          </div>
           <h1 id="marketing-title">A smart dashboard for your home, built for the kitchen wall.</h1>
           <p>Calendar, to-dos, meal plan, and countdowns — all on a tablet mounted where your family actually gathers.</p>
           <div class="marketing-actions">
@@ -686,42 +673,28 @@
               <i data-lucide="calendar-days"></i>
               <span>Calendar</span>
             </div>
-            <span class="marketing-card-badge">Week</span>
           </div>
           <div class="marketing-calendar">
             <div class="marketing-calendar-weekdays">
-              <span>Mon</span>
-              <span>Tue</span>
               <span>Wed</span>
               <span>Thu</span>
               <span>Fri</span>
               <span>Sat</span>
-              <span>Sun</span>
             </div>
             <div class="marketing-calendar-days">
               <div class="marketing-calendar-day">
-                <strong>12</strong>
+                <strong>14</strong>
                 <span class="marketing-pill marketing-pill--amber">Piano</span>
               </div>
               <div class="marketing-calendar-day">
-                <strong>13</strong>
-              </div>
-              <div class="marketing-calendar-day">
-                <strong>14</strong>
+                <strong>15</strong>
                 <span class="marketing-pill marketing-pill--green">Dinner</span>
               </div>
               <div class="marketing-calendar-day">
-                <strong>15</strong>
-              </div>
-              <div class="marketing-calendar-day">
                 <strong>16</strong>
-                <span class="marketing-pill marketing-pill--ink">Game Night</span>
               </div>
               <div class="marketing-calendar-day">
                 <strong>17</strong>
-              </div>
-              <div class="marketing-calendar-day">
-                <strong>18</strong>
               </div>
             </div>
           </div>
@@ -773,16 +746,11 @@
               <i data-lucide="timer-reset"></i>
               <span>Countdowns</span>
             </div>
-            <span class="marketing-card-badge">Live</span>
           </div>
           <div class="marketing-countdown">
-            <div class="marketing-countdown-badge">
-              <i data-lucide="sparkles"></i>
-              Looking forward
-            </div>
-            <div class="marketing-countdown-title">Bailey &amp; Chris 🎉</div>
-            <div class="marketing-countdown-number">147</div>
-            <div class="marketing-countdown-caption">days</div>
+            <div class="marketing-countdown-title">Summer Vacation 🌴</div>
+            <div class="marketing-countdown-number">38</div>
+            <div class="marketing-countdown-caption">DAYS</div>
           </div>
         </article>
       </section>
@@ -793,21 +761,21 @@
             <i data-lucide="calendar-days"></i>
           </div>
           <h2>Always up to date</h2>
-          <p>Syncs with Google Calendar automatically.</p>
+          <p>Connect your Google Calendar once and it shows up automatically, always current.</p>
         </article>
         <article class="marketing-feature">
           <div class="marketing-feature-icon">
             <i data-lucide="users"></i>
           </div>
           <h2>Built for households</h2>
-          <p>Multiple members, shared to-dos, meal planning.</p>
+          <p>Add family members, share to-dos, plan meals together, and keep everyone on the same page.</p>
         </article>
         <article class="marketing-feature">
           <div class="marketing-feature-icon">
             <i data-lucide="timer"></i>
           </div>
           <h2>Count down together</h2>
-          <p>See what&apos;s coming up as a family.</p>
+          <p>Add vacations, birthdays, holidays — anything worth looking forward to, visible to the whole household.</p>
         </article>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -372,10 +372,10 @@
       display: flex;
       flex-direction: column;
       gap: 10px;
-      padding: 16px;
-      border-radius: 20px;
+      padding: 12px;
+      border-radius: 18px;
       border: 1px solid rgba(28, 25, 23, 0.08);
-      background: #F8F3EA;
+      background: #FFFDF7;
     }
 
     .marketing-calendar-days {
@@ -433,10 +433,10 @@
       width: 100%;
       display: grid;
       gap: 10px;
-      padding: 16px;
-      border-radius: 20px;
+      padding: 12px;
+      border-radius: 18px;
       border: 1px solid rgba(28, 25, 23, 0.08);
-      background: #F8F3EA;
+      background: #FFFDF7;
     }
 
     .marketing-todo-row {
@@ -489,10 +489,10 @@
       width: 100%;
       display: grid;
       gap: 0;
-      padding: 16px;
-      border-radius: 20px;
+      padding: 12px;
+      border-radius: 18px;
       border: 1px solid rgba(28, 25, 23, 0.08);
-      background: #F8F3EA;
+      background: #FFFDF7;
       grid-template-columns: 1fr;
       overflow: hidden;
     }
@@ -532,24 +532,24 @@
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      gap: 12px;
+      gap: 8px;
       min-height: 100%;
       text-align: center;
-      padding: 18px 16px;
-      border-radius: 20px;
+      padding: 12px;
+      border-radius: 18px;
       border: 1px solid rgba(28, 25, 23, 0.08);
-      background: #F8F3EA;
+      background: #FFFDF7;
     }
 
     .marketing-countdown-title {
       font-family: "Fraunces", serif;
-      font-size: clamp(1.3rem, 2vw, 1.65rem);
-      line-height: 1.15;
+      font-size: clamp(1.05rem, 1.5vw, 1.35rem);
+      line-height: 1.1;
     }
 
     .marketing-countdown-number {
       font-family: "Bricolage Grotesque", "Manrope", sans-serif;
-      font-size: clamp(4rem, 7vw, 5.2rem);
+      font-size: clamp(3.1rem, 5.4vw, 4.1rem);
       line-height: 0.9;
       letter-spacing: -0.05em;
       color: var(--marketing-accent);
@@ -561,6 +561,11 @@
       letter-spacing: 0.12em;
       text-transform: uppercase;
       font-weight: 800;
+    }
+
+    .marketing-pill--slate {
+      background: rgba(120, 113, 108, 0.16);
+      color: var(--marketing-text);
     }
 
     .marketing-cta-band {
@@ -725,6 +730,7 @@
                   </div>
                   <div class="marketing-calendar-day">
                     <strong>23</strong>
+                    <span class="marketing-pill marketing-pill--slate">B-Day</span>
                   </div>
                 </div>
               </div>

--- a/index.html
+++ b/index.html
@@ -338,9 +338,10 @@
 
     .marketing-card-preview {
       width: 100%;
+      height: 180px;
       flex: 1 1 auto;
       display: flex;
-      align-items: stretch;
+      align-items: center;
     }
 
     .marketing-card-copy {
@@ -373,18 +374,10 @@
       background: #F8F3EA;
     }
 
-    .marketing-calendar-weekdays,
     .marketing-calendar-days {
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 8px;
-    }
-
-    .marketing-calendar-weekdays span {
-      color: var(--marketing-muted);
-      font-size: 0.78rem;
-      font-weight: 800;
-      text-align: center;
     }
 
     .marketing-calendar-day {
@@ -496,26 +489,23 @@
       border-radius: 20px;
       border: 1px solid rgba(28, 25, 23, 0.08);
       background: #F8F3EA;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-template-columns: 1fr;
       overflow: hidden;
     }
 
     .marketing-meal-cell {
       min-width: 0;
       display: grid;
-      gap: 8px;
+      grid-template-columns: auto minmax(0, 1fr);
+      align-items: center;
+      gap: 16px;
       padding: 12px 10px;
       background: rgba(255, 253, 247, 0.84);
       border-top: 1px solid rgba(28, 25, 23, 0.08);
-      border-right: 1px solid rgba(28, 25, 23, 0.08);
     }
 
-    .marketing-meal-cell:nth-child(-n + 3) {
+    .marketing-meal-cell:first-child {
       border-top: 0;
-    }
-
-    .marketing-meal-cell:nth-child(3n) {
-      border-right: 0;
     }
 
     .marketing-meal-day {
@@ -574,7 +564,7 @@
       align-items: center;
       justify-content: space-between;
       gap: 24px;
-      padding: 48px 32px;
+      padding: 24px 32px;
       border-radius: 28px;
       background: var(--marketing-accent);
       box-shadow: 0 24px 44px rgba(180, 83, 9, 0.24);
@@ -635,7 +625,7 @@
       }
 
       .marketing-cta-band {
-        padding: 44px 28px;
+        padding: 22px 28px;
       }
     }
 
@@ -675,7 +665,7 @@
         flex-direction: column;
         align-items: stretch;
         gap: 20px;
-        padding: 40px 22px;
+        padding: 22px 22px;
       }
     }
 
@@ -692,8 +682,8 @@
           <img src="homeboard_logo.svg" alt="Homeboard" width="144" decoding="async">
         </div>
         <div class="marketing-hero-copy">
-          <h1 id="marketing-title">A smart dashboard for your home, built for the kitchen wall.</h1>
-          <p>Calendar, to-dos, meal plan, and countdowns — all on a tablet mounted where your family actually gathers.</p>
+          <h1 id="marketing-title">A smart dashboard for your home built for the kitchen wall.</h1>
+          <p>Calendar, to-dos, meal planning, and countdowns — all on a tablet mounted where your family actually gathers.</p>
           <div class="marketing-actions">
             <a class="marketing-button marketing-button--primary" href="/signup">Get started</a>
             <a class="marketing-button marketing-button--secondary" href="/admin">Already have an account?</a>
@@ -709,11 +699,6 @@
             </div>
             <div class="marketing-card-preview">
               <div class="marketing-calendar">
-                <div class="marketing-calendar-weekdays">
-                  <span>Wed</span>
-                  <span>Thu</span>
-                  <span>Fri</span>
-                </div>
                 <div class="marketing-calendar-days">
                   <div class="marketing-calendar-day">
                     <strong>14</strong>
@@ -726,12 +711,24 @@
                     <strong>16</strong>
                   </div>
                 </div>
+                <div class="marketing-calendar-days">
+                  <div class="marketing-calendar-day">
+                    <strong>21</strong>
+                  </div>
+                  <div class="marketing-calendar-day">
+                    <strong>22</strong>
+                    <span class="marketing-pill marketing-pill--green">Piano</span>
+                  </div>
+                  <div class="marketing-calendar-day">
+                    <strong>23</strong>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
           <div class="marketing-card-copy">
             <h2>Calendar</h2>
-            <p>Syncs with Google Calendar so everyone sees what&apos;s coming up.</p>
+            <p>Syncs with Google Calendar so everyone sees what&apos;s coming up. Color-coded by calendar, today always highlighted.</p>
           </div>
         </article>
 

--- a/index.html
+++ b/index.html
@@ -338,15 +338,19 @@
 
     .marketing-card-preview {
       width: 100%;
-      height: 180px;
+      height: 160px;
       flex: 1 1 auto;
       display: flex;
       align-items: center;
+      justify-content: center;
+      overflow: hidden;
     }
 
     .marketing-card-copy {
       display: grid;
       gap: 8px;
+      min-height: 92px;
+      align-content: start;
     }
 
     .marketing-card-copy h2 {
@@ -728,7 +732,7 @@
           </div>
           <div class="marketing-card-copy">
             <h2>Calendar</h2>
-            <p>Syncs with Google Calendar so everyone sees what&apos;s coming up. Color-coded by calendar, today always highlighted.</p>
+            <p>Syncs with Google Calendar so everyone sees what&apos;s coming up. Color-coded by calendar.</p>
           </div>
         </article>
 
@@ -820,7 +824,7 @@
       </section>
 
       <footer class="marketing-footer">
-        Already set up your display? Go to <a href="/display">/display</a> on your tablet.
+        Already set up? Go to <a href="/display">/display</a> on your tablet.
       </footer>
     </div>
   </main>

--- a/index.html
+++ b/index.html
@@ -347,6 +347,10 @@
       overflow: hidden;
     }
 
+    .marketing-card-preview--todos {
+      padding-block: 12px;
+    }
+
     .marketing-card-copy {
       display: grid;
       gap: 8px;
@@ -750,7 +754,7 @@
             <div class="marketing-card-label">
               <i data-lucide="list-todo"></i>
             </div>
-            <div class="marketing-card-preview">
+            <div class="marketing-card-preview marketing-card-preview--todos">
               <div class="marketing-todos">
                 <div class="marketing-todo-row">
                   <span class="marketing-todo-check" aria-hidden="true"></span>

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.35";
+    const VERSION = "2.0.36";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.33";
+    const VERSION = "2.0.34";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.34";
+    const VERSION = "2.0.35";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.32";
+    const VERSION = "2.0.33";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.37";
+    const VERSION = "2.0.38";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.36";
+    const VERSION = "2.0.37";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.39";
+    const VERSION = "2.0.40";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.38";
+    const VERSION = "2.0.39";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -4,6 +4,8 @@
     const UNSPLASH_ACCESS_KEY = '%%UNSPLASH_ACCESS_KEY%%';
     const pathname = window.location.pathname.replace(/\/+$/, "") || "/";
     const isAdminMode = pathname === "/admin";
+    const isDisplayMode = pathname === "/display";
+    const isMarketingMode = !isAdminMode && !isDisplayMode;
     let sb = null;
 
     function initSupabaseClient() {
@@ -34,8 +36,9 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.30";
+    const VERSION = "2.0.31";
     const rotationIntervalMs = 30000;
+    const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");
     const adminApp = document.getElementById("admin-app");
     const LAST_SYNCED_KEY = "homeboard_last_synced";
@@ -1705,8 +1708,21 @@
     function init() {
       if (isAdminMode) {
         initAdminMode();
-      } else {
+      } else if (isDisplayMode) {
         initDisplayMode();
+      } else if (isMarketingMode) {
+        if (marketingApp) {
+          marketingApp.hidden = false;
+        }
+        if (displayApp) {
+          displayApp.hidden = true;
+        }
+        if (adminApp) {
+          adminApp.hidden = true;
+        }
+        if (typeof refreshIcons === "function") {
+          refreshIcons();
+        }
       }
 
       registerServiceWorker();

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.31";
+    const VERSION = "2.0.32";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,8 @@
   from = "/admin"
   to = "/index.html"
   status = 200
+
+[[redirects]]
+  from = "/display"
+  to = "/index.html"
+  status = 200

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.34";
+const CACHE_NAME = "homeboard-v2.0.35";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.35";
+const CACHE_NAME = "homeboard-v2.0.36";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.32";
+const CACHE_NAME = "homeboard-v2.0.33";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,8 @@
-const CACHE_NAME = "homeboard-v2.0.30";
+const CACHE_NAME = "homeboard-v2.0.31";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",
+  "/display",
   "./signup.html",
   "./manifest.json",
   "./manifest-admin.json",
@@ -52,10 +53,31 @@ self.addEventListener("fetch", (event) => {
       event.request.destination === "script" ||
       event.request.destination === "style" ||
       event.request.destination === "document" ||
-      requestUrl.pathname === "/" ||
+      requestUrl.pathname === "/display" ||
+      requestUrl.pathname === "/admin" ||
       requestUrl.pathname.endsWith(".html") ||
       requestUrl.pathname.endsWith(".json")
     );
+
+  function getNavigationFallback() {
+    if (requestUrl.pathname === "/signup") {
+      return caches.match("./signup.html");
+    }
+
+    if (requestUrl.pathname === "/display") {
+      return caches.match("/display").then((response) => response || caches.match("./index.html"));
+    }
+
+    if (requestUrl.pathname === "/admin") {
+      return caches.match("./index.html");
+    }
+
+    if (requestUrl.pathname === "/") {
+      return caches.match("./").then((response) => response || caches.match("./index.html"));
+    }
+
+    return caches.match("./index.html");
+  }
 
   event.respondWith(
     isLocalAppShellRequest
@@ -77,7 +99,7 @@ self.addEventListener("fetch", (event) => {
             }
 
             if (event.request.mode === "navigate") {
-              return caches.match("./index.html");
+              return getNavigationFallback();
             }
 
             throw new Error("Network request failed");
@@ -99,7 +121,7 @@ self.addEventListener("fetch", (event) => {
             return networkResponse;
           }).catch(() => {
             if (event.request.mode === "navigate") {
-              return caches.match("./index.html");
+              return getNavigationFallback();
             }
 
             throw new Error("Network request failed");

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.36";
+const CACHE_NAME = "homeboard-v2.0.37";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.37";
+const CACHE_NAME = "homeboard-v2.0.38";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.31";
+const CACHE_NAME = "homeboard-v2.0.32";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.38";
+const CACHE_NAME = "homeboard-v2.0.39";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.39";
+const CACHE_NAME = "homeboard-v2.0.40";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.33";
+const CACHE_NAME = "homeboard-v2.0.34";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary
- move display mode from `/` to `/display` while keeping `/admin` unchanged
- add a new marketing landing page at `/` inside `index.html`
- update Netlify rewrites and service worker caching for the new route structure
- bump the shipped version and cache key to `2.0.31`
- update the README route documentation

## Validation
- reviewed the routing logic in `index.html` and `js/shared.js` to keep admin boot unchanged and route display boot to `/display`
- reviewed `sw.js` so `/display` is cached and offline fallbacks match the new route behavior
- did not run `netlify dev` or a live browser verification in this session

AI-assisted: Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Introduced a responsive marketing landing page at the application root path as the primary entry point
* Dedicated `/display` route for wall-mounted display mode and related functionality
* Improved offline experience with route-specific fallback pages and better error handling during network failures

**Documentation**
* Updated documentation covering new routes, operational modes, and deployment configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisaug21/homeboard/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->