### PR TITLE
Redesign scorecard past games cards

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -3056,6 +3056,11 @@
       border: 1px solid var(--border);
     }
 
+    .admin-scorecard-history-card {
+      display: grid;
+      gap: 16px;
+    }
+
     .admin-scorecard-log-card,
     .admin-scorecard-log-head,
     .admin-scorecard-log-meta {
@@ -3226,6 +3231,10 @@
     .admin-scorecard-history-meta strong {
       font-size: 0.94rem;
       line-height: 1.35;
+    }
+
+    .admin-scorecard-history-meta {
+      margin-bottom: 2px;
     }
 
     .admin-scorecard-history-meta span {

--- a/css/admin.css
+++ b/css/admin.css
@@ -2987,8 +2987,7 @@
 
     .admin-scorecard-card-head,
     .admin-scorecard-section-head,
-    .admin-scorecard-form-header,
-    .admin-scorecard-history-head {
+    .admin-scorecard-form-header {
       display: flex;
       align-items: flex-start;
       justify-content: space-between;
@@ -3004,8 +3003,7 @@
     }
 
     .admin-scorecard-card-meta,
-    .admin-scorecard-summary-empty,
-    .admin-scorecard-history-winner {
+    .admin-scorecard-summary-empty {
       color: var(--muted);
       font-size: 0.86rem;
     }
@@ -3033,16 +3031,6 @@
 
     .admin-scorecard-filter-row .admin-button {
       width: 100%;
-    }
-
-    .admin-scorecard-history-pill {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 6px 10px;
-      border-radius: var(--tag-radius);
-      font-size: 0.82rem;
-      font-weight: 700;
     }
 
     .admin-scorecard-modal-stack,
@@ -3235,45 +3223,54 @@
       min-width: 0;
     }
 
+    .admin-scorecard-history-meta strong {
+      font-size: 0.94rem;
+      line-height: 1.35;
+    }
+
     .admin-scorecard-history-meta span {
       color: var(--muted);
       font-size: 0.82rem;
     }
 
-    .admin-scorecard-history-winner-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 6px 10px;
-      border-radius: var(--tag-radius);
-      background: var(--color-accent-subtle);
-      color: var(--color-accent);
-      font-size: 0.82rem;
-      font-weight: 800;
-      white-space: nowrap;
-    }
-
-    .admin-scorecard-history-winner-badge svg,
-    .admin-scorecard-history-pill svg {
-      width: 14px;
-      height: 14px;
-      flex-shrink: 0;
-    }
-
     .admin-scorecard-history-pill {
-      background: var(--panel-strong);
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 12px;
+      border-radius: 16px;
+      background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
       color: var(--ink);
       border: 1px solid var(--border);
     }
 
+    .admin-scorecard-history-pill-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--amber);
+    }
+
+    .admin-scorecard-history-pill-icon svg {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+
+    .admin-scorecard-history-pill-name {
+      min-width: 0;
+      font-size: 0.86rem;
+      font-weight: 700;
+    }
+
     .admin-scorecard-history-pill strong {
-      font-size: 0.82rem;
+      font-size: 0.88rem;
     }
 
     .admin-scorecard-history-pill.is-winner {
-      background: var(--color-accent-subtle);
-      color: var(--color-accent);
-      border-color: var(--color-accent);
+      background: color-mix(in srgb, var(--amber-soft) 90%, var(--panel));
+      border-color: color-mix(in srgb, var(--amber) 56%, var(--border));
     }
 
     .admin-scorecard-adjust-player {
@@ -3628,11 +3625,6 @@
       .admin-scorecard-adjust-grid-buttons {
         grid-template-columns: repeat(3, minmax(0, 1fr));
       }
-      .admin-scorecard-history-head {
-        flex-direction: column;
-        align-items: stretch;
-      }
-
       .admin-actions--split.admin-actions--stacked {
         flex-direction: column;
       }

--- a/css/display.css
+++ b/css/display.css
@@ -2736,12 +2736,16 @@
 
     .scorecard-history-list {
       margin-top: 12px;
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      align-content: start;
       max-height: min(34dvh, 320px);
       overflow-y: auto;
       padding-right: 4px;
     }
 
     .scorecard-history-item {
+      min-width: 0;
       padding: 14px;
       display: grid;
       gap: 12px;

--- a/css/display.css
+++ b/css/display.css
@@ -2736,31 +2736,73 @@
 
     .scorecard-history-list {
       margin-top: 12px;
+      max-height: min(34dvh, 320px);
+      overflow-y: auto;
+      padding-right: 4px;
     }
 
     .scorecard-history-item {
-      padding: 12px 14px;
+      padding: 14px;
       display: grid;
-      gap: 10px;
+      gap: 12px;
     }
 
-    .scorecard-history-head,
-    .scorecard-history-scores {
+    .scorecard-history-head {
       display: flex;
       justify-content: space-between;
-      flex-wrap: wrap;
       gap: 8px;
       color: var(--muted);
       font-size: 0.86rem;
     }
 
+    .scorecard-history-head strong {
+      line-height: 1.35;
+    }
+
+    .scorecard-history-scores {
+      display: grid;
+      gap: 8px;
+    }
+
     .scorecard-history-pill {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 10px;
+      width: 100%;
+      padding: 10px 12px;
+      border-radius: 16px;
+      background: color-mix(in srgb, var(--panel-strong) 78%, transparent);
+      color: var(--ink);
+      border: 1px solid var(--border);
+      font-size: 0.82rem;
+      font-weight: 700;
+    }
+
+    .scorecard-history-pill-icon {
       display: inline-flex;
       align-items: center;
-      padding: 5px 9px;
-      border-radius: var(--tag-radius);
-      font-size: 0.8rem;
-      font-weight: 700;
+      justify-content: center;
+      color: var(--amber);
+    }
+
+    .scorecard-history-pill-icon svg {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+
+    .scorecard-history-pill-name {
+      min-width: 0;
+    }
+
+    .scorecard-history-pill strong {
+      justify-self: end;
+    }
+
+    .scorecard-history-pill.is-winner {
+      background: color-mix(in srgb, var(--amber-soft) 92%, var(--panel));
+      border-color: color-mix(in srgb, var(--amber) 52%, var(--border));
     }
 
     .scorecard-bonus-row {

--- a/js/admin-scorecard.js
+++ b/js/admin-scorecard.js
@@ -498,7 +498,7 @@
       return `
         <article class="admin-scorecard-history-card">
           <div class="admin-scorecard-history-meta">
-            <strong>${escapeHtml(formatScorecardHistoryDate(session.endedAt || session.startedAt))}</strong>
+            <strong>${escapeHtml(formatScorecardHistoryDateRange(session.startedAt, session.endedAt))}</strong>
           </div>
           <div class="admin-scorecard-history-scores">
             ${scorecard.players.map((player) => `

--- a/js/admin-scorecard.js
+++ b/js/admin-scorecard.js
@@ -494,26 +494,21 @@
     }
 
     function buildScorecardHistoryEntryHTML(scorecard, session) {
-      const winnerLabel = session.winner || "Tie";
+      const winningPlayers = new Set(getScorecardLeaders(session.scores, scorecard.players));
       return `
         <article class="admin-scorecard-history-card">
-          <div class="admin-scorecard-history-head">
-            <div class="admin-scorecard-history-meta">
-              <strong>${escapeHtml(formatScorecardSessionDate(session.endedAt || session.startedAt))}</strong>
-              <span>${escapeHtml(formatScorecardSessionDuration(session.startedAt, session.endedAt))}</span>
-            </div>
-            <span class="admin-scorecard-history-winner-badge">
-              <i data-lucide="trophy"></i>
-              ${escapeHtml(winnerLabel)}
-            </span>
+          <div class="admin-scorecard-history-meta">
+            <strong>${escapeHtml(formatScorecardHistoryDate(session.endedAt || session.startedAt))}</strong>
           </div>
           <div class="admin-scorecard-history-scores">
             ${scorecard.players.map((player) => `
-              <span class="admin-scorecard-history-pill${winnerLabel === player.name ? " is-winner" : ""}">
-                ${winnerLabel === player.name ? '<i data-lucide="trophy"></i>' : ""}
-                <span>${escapeHtml(player.name)}</span>
+              <div class="admin-scorecard-history-pill${winningPlayers.has(player.name) ? " is-winner" : ""}">
+                <span class="admin-scorecard-history-pill-icon" aria-hidden="true">
+                  <i data-lucide="trophy"${winningPlayers.has(player.name) ? "" : ' style="visibility:hidden"'}></i>
+                </span>
+                <span class="admin-scorecard-history-pill-name">${escapeHtml(player.name)}</span>
                 <strong>${escapeHtml(formatScorecardScore(getScorecardPlayerScore(session.scores, player, scorecard.players)))}</strong>
-              </span>
+              </div>
             `).join("")}
           </div>
         </article>

--- a/js/display-scorecards.js
+++ b/js/display-scorecards.js
@@ -368,7 +368,7 @@
               return `
                 <article class="scorecard-history-item">
                   <div class="scorecard-history-head">
-                    <strong>${escapeHtml(formatScorecardHistoryDate(session.endedAt || session.startedAt))}</strong>
+                    <strong>${escapeHtml(formatScorecardHistoryDateRange(session.startedAt, session.endedAt))}</strong>
                   </div>
                   <div class="scorecard-history-scores">
                     ${scorecard.players.map((player) => `

--- a/js/display-scorecards.js
+++ b/js/display-scorecards.js
@@ -363,19 +363,27 @@
         <details class="scorecard-history">
           <summary>Past games</summary>
           <div class="scorecard-history-list">
-            ${sessions.map((session) => `
-              <article class="scorecard-history-item">
-                <div class="scorecard-history-head">
-                  <strong>${escapeHtml(formatScorecardSessionDate(session.endedAt || session.startedAt))}</strong>
-                  <span>${escapeHtml(session.winner || "Tie")}</span>
-                </div>
-                <div class="scorecard-history-scores">
-                  ${scorecard.players.map((player) => `
-                    <span class="scorecard-history-pill" style="background:${escapeHtml(hexToRgba(player.color, 0.14))};color:${escapeHtml(player.color)}">${escapeHtml(player.name)} ${escapeHtml(formatScorecardScore(getScorecardPlayerScore(session.scores, player, scorecard.players)))}</span>
-                  `).join("")}
-                </div>
-              </article>
-            `).join("")}
+            ${sessions.map((session) => {
+              const winningPlayers = new Set(getScorecardLeaders(session.scores, scorecard.players));
+              return `
+                <article class="scorecard-history-item">
+                  <div class="scorecard-history-head">
+                    <strong>${escapeHtml(formatScorecardHistoryDate(session.endedAt || session.startedAt))}</strong>
+                  </div>
+                  <div class="scorecard-history-scores">
+                    ${scorecard.players.map((player) => `
+                      <div class="scorecard-history-pill${winningPlayers.has(player.name) ? " is-winner" : ""}">
+                        <span class="scorecard-history-pill-icon" aria-hidden="true">
+                          <i data-lucide="trophy"${winningPlayers.has(player.name) ? "" : ' style="visibility:hidden"'}></i>
+                        </span>
+                        <span class="scorecard-history-pill-name">${escapeHtml(player.name)}</span>
+                        <strong>${escapeHtml(formatScorecardScore(getScorecardPlayerScore(session.scores, player, scorecard.players)))}</strong>
+                      </div>
+                    `).join("")}
+                  </div>
+                </article>
+              `;
+            }).join("")}
           </div>
         </details>
       `;

--- a/js/display-todos.js
+++ b/js/display-todos.js
@@ -36,7 +36,7 @@
           "fireworks",
           "bubble-float",
           "thumbs-up-bounce",
-          "sparkle-trail",
+          "ripple-rings",
           "ink-splash"
         ];
 
@@ -499,7 +499,7 @@
           return playGsapBubbleFloat(origin);
         case "thumbs-up-bounce":
           return playGsapThumbsUp(origin);
-        case "sparkle-trail":
+        case "ripple-rings":
           return playRippleRings(origin);
         case "ink-splash":
           return playGsapInkSplash(origin);

--- a/js/display-todos.js
+++ b/js/display-todos.js
@@ -485,10 +485,8 @@
       }
 
       const animationName = getDisplayCelebrationAnimationName();
-      // DEBUG: set window.__DEBUG_CELEBRATIONS__ = true in console to enable
-      if (window.__DEBUG_CELEBRATIONS__ === true) {
-        showDisplayCelebrationDebugLabel(animationName);
-      }
+      // Temporary always-on debug label for tablet-side celebration QA.
+      showDisplayCelebrationDebugLabel(animationName);
       const origin = getTodoCelebrationOrigin(cardEl);
       switch (animationName) {
         case "confetti-burst":

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.40";
+    const VERSION = "2.0.41";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");
@@ -904,6 +904,24 @@
       }).format(date);
     }
 
+    function formatScorecardHistoryDate(value) {
+      if (!value) {
+        return "Unknown date";
+      }
+
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        return "Unknown date";
+      }
+
+      return new Intl.DateTimeFormat("en-US", {
+        month: "long",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit"
+      }).format(date).replace(",", " at");
+    }
+
     function formatScoreEventTime(value) {
       const date = new Date(value);
       if (Number.isNaN(date.getTime())) {
@@ -925,24 +943,6 @@
         default:
           return "Increment";
       }
-    }
-
-    function formatScorecardSessionDuration(startedAt, endedAt) {
-      const start = startedAt ? new Date(startedAt) : null;
-      const end = endedAt ? new Date(endedAt) : null;
-
-      if (!start || !end || Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
-        return "Duration unknown";
-      }
-
-      const totalMinutes = Math.max(0, Math.round((end - start) / 60000));
-      if (totalMinutes < 60) {
-        return `${totalMinutes}m`;
-      }
-
-      const hours = Math.floor(totalMinutes / 60);
-      const minutes = totalMinutes % 60;
-      return minutes ? `${hours}h ${minutes}m` : `${hours}h`;
     }
 
     function formatRelativeTimestamp(value, emptyLabel = "") {

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.43";
+    const VERSION = "2.0.44";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");
@@ -925,6 +925,9 @@
       const endDate = formatDate(endValue);
 
       if (startDate && endDate) {
+        if (startDate === endDate) {
+          return startDate;
+        }
         return `${startDate} → ${endDate}`;
       }
 

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.44";
+    const VERSION = "2.0.45";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.42";
+    const VERSION = "2.0.43";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");
@@ -904,22 +904,31 @@
       }).format(date);
     }
 
-    function formatScorecardHistoryDate(value) {
-      if (!value) {
-        return "Unknown date";
+    function formatScorecardHistoryDateRange(startValue, endValue) {
+      const formatDate = (value) => {
+        if (!value) {
+          return null;
+        }
+
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+          return null;
+        }
+
+        return new Intl.DateTimeFormat("en-US", {
+          month: "long",
+          day: "numeric"
+        }).format(date);
+      };
+
+      const startDate = formatDate(startValue);
+      const endDate = formatDate(endValue);
+
+      if (startDate && endDate) {
+        return `${startDate} → ${endDate}`;
       }
 
-      const date = new Date(value);
-      if (Number.isNaN(date.getTime())) {
-        return "Unknown date";
-      }
-
-      return new Intl.DateTimeFormat("en-US", {
-        month: "long",
-        day: "numeric",
-        hour: "numeric",
-        minute: "2-digit"
-      }).format(date).replace(",", " at");
+      return startDate || endDate || "Unknown date";
     }
 
     function formatScoreEventTime(value) {

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.41";
+    const VERSION = "2.0.42";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.42";
+const CACHE_NAME = "homeboard-v2.0.43";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.40";
+const CACHE_NAME = "homeboard-v2.0.41";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.43";
+const CACHE_NAME = "homeboard-v2.0.44";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.44";
+const CACHE_NAME = "homeboard-v2.0.45";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.41";
+const CACHE_NAME = "homeboard-v2.0.42";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",


### PR DESCRIPTION
## Summary
- redesign past scorecard games in admin and display as card-based player rows with winner highlighting
- compute winners from the highest rendered score, including ties, and remove the old winner banner and elapsed-time text
- add scrolling to the display past-games list and bump the shipped version to `v2.0.41`

## Why
The old history cards duplicated winner information, showed an unhelpful elapsed-time counter, and had inconsistent player row layout in display mode.

## Impact
Past games are easier to scan in both surfaces, tie winners are shown correctly, and long display histories no longer overflow the available space.

## Validation
- `node --check js/shared.js`
- `node --check js/admin-scorecard.js`
- `node --check js/display-scorecards.js`

AI-assisted: Codex