### PR TITLE
[codex] Mask locked bonus wagers on display

### DIFF
--- a/css/display.css
+++ b/css/display.css
@@ -2878,6 +2878,20 @@
       font-weight: 800;
     }
 
+    .scorecard-bonus-mask {
+      width: 110px;
+      min-width: 0;
+      border: 1px solid var(--color-accent);
+      border-radius: var(--button-radius);
+      padding: 10px 12px;
+      background: var(--color-accent-subtle);
+      color: var(--color-accent);
+      font: inherit;
+      font-weight: 800;
+      letter-spacing: 0.04em;
+      text-align: center;
+    }
+
     .scorecard-bonus-peek-btn {
       position: absolute;
       right: 8px;

--- a/js/display-scorecards.js
+++ b/js/display-scorecards.js
@@ -471,8 +471,10 @@
                     <div class="scorecard-bonus-entry-side">
                       <div class="scorecard-bonus-entry-controls">
                         <div class="scorecard-bonus-input-wrap${isLocked ? " is-locked" : ""}">
-                          <input class="scorecard-bonus-input${isLocked ? " is-locked" : ""}" type="password" inputmode="numeric" autocomplete="off" pattern="[0-9]*" min="0" max="${escapeHtml(currentScore)}" value="${escapeHtml(isLocked ? String(lockedWager) : String(draftWager || ""))}" data-scorecard-bonus-input="${escapeHtml(inputKey)}" data-scorecard-bonus-max="${escapeHtml(currentScore)}"${isLocked ? " disabled" : ""}>
-                          ${isLocked ? "" : `<button class="scorecard-bonus-peek-btn" type="button" data-action="scorecard-bonus-peek" data-scorecard-bonus-peek-target="${escapeHtml(inputKey)}"${draftWager ? "" : " disabled"} aria-label="Toggle wager visibility"><i data-lucide="eye"></i></button>`}
+                          ${isLocked
+                            ? '<div class="scorecard-bonus-mask" aria-label="Wager locked and hidden">Hidden</div>'
+                            : `<input class="scorecard-bonus-input" type="password" inputmode="numeric" autocomplete="off" pattern="[0-9]*" min="0" max="${escapeHtml(currentScore)}" value="${escapeHtml(String(draftWager || ""))}" data-scorecard-bonus-input="${escapeHtml(inputKey)}" data-scorecard-bonus-max="${escapeHtml(currentScore)}">
+                          <button class="scorecard-bonus-peek-btn" type="button" data-action="scorecard-bonus-peek" data-scorecard-bonus-peek-target="${escapeHtml(inputKey)}"${draftWager ? "" : " disabled"} aria-label="Toggle wager visibility"><i data-lucide="eye"></i></button>`}
                         </div>
                         <button class="scorecard-secondary-btn scorecard-bonus-lock-btn${isLocked ? " is-locked" : ""}" type="button" data-action="scorecard-bonus-lock" data-scorecard-id="${escapeHtml(scorecard.id)}" data-player-name="${escapeHtml(player.name)}"${isLocked ? " disabled" : ""}>${isLocked ? '<i data-lucide="lock"></i><span>Locked</span>' : "Lock in"}</button>
                       </div>

--- a/js/shared.js
+++ b/js/shared.js
@@ -36,7 +36,7 @@
       return sb || initSupabaseClient();
     }
 
-    const VERSION = "2.0.45";
+    const VERSION = "2.0.46";
     const rotationIntervalMs = 30000;
     const marketingApp = document.getElementById("marketing-app");
     const displayApp = document.getElementById("display-app");

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "homeboard-v2.0.45";
+const CACHE_NAME = "homeboard-v2.0.46";
 const ASSETS_TO_CACHE = [
   "./",
   "./index.html",


### PR DESCRIPTION
## What changed
This updates the display-side bonus round entry UI so a locked wager no longer remains in a password input.

Instead, once a player locks a wager, the display shows a fixed `Hidden` badge. The actual wager is still kept in local/session state for the reveal and apply-results steps.

This PR also bumps the shipped version and service worker cache key to `v2.0.46`.

## Why
The previous implementation masked the wager value, but it still revealed the number of digits because password inputs render one bullet per character. On a shared display, that let other players infer whether a wager was small or large.

## Impact
Players using the shared display can now enter and lock bonus wagers without leaking digit length to the next player. Reveal and scoring behavior are unchanged.

## Root cause
A locked wager was rendered back into the DOM as a disabled `type="password"` input, which preserved the character count visually.

## Validation
Code review only.
Recommended manual check:
- Start a bonus round on the display
- Enter wagers with different digit lengths for different players
- Lock them in and confirm each locked row shows the same fixed hidden state
- Reveal wagers and confirm scoring still works

## AI assistance
Authored with Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated visual styling for bonus round mask elements.

* **Bug Fixes**
  * Modified bonus round wager entry display: locked wagers now appear as masked elements instead of disabled inputs. Wager peek button is now consistently available during the entry phase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisaug21/homeboard/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->